### PR TITLE
- Get Instance from reactActivity.getApplicationContext().

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -37,7 +37,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
   private static Branch mBranch = null;
 
   public static void initSession(final Uri uri, ReactActivity reactActivity) {
-    mBranch = Branch.getInstance();
+    mBranch = Branch.getInstance(reactActivity.getApplicationContext());
     mActivity = reactActivity;
     mBranch.initSession(new Branch.BranchReferralInitListener(){
 


### PR DESCRIPTION
 Fixes crash on app start on Android.