### PR TITLE
Fixes null linkProperties in iOS generateShortUrl()

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -214,7 +214,7 @@ RCT_EXPORT_METHOD(
   rejecter:(RCTPromiseRejectBlock)reject
 ){
   BranchUniversalObject *branchUniversalObject = [self createBranchUniversalObject:branchUniversalObjectMap];
-  BranchLinkProperties *linkProperties = [self createLinkProperties:linkProperties withControlParams:controlParamsMap];
+  BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:controlParamsMap];
 
   [branchUniversalObject getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
     if (!error) {


### PR DESCRIPTION
Pretty much the same as #21