### PR TITLE
Fix for issue #20

### DIFF
--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -6,7 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNBranch : NSObject <RCTBridgeModule>
 


### PR DESCRIPTION
## TL;DR
This change along with #22, fixes #20

## Long Story

Issue #22 solves the case, when you integrate existing project with react-native, and want to use CocoaPods for react-native-branch for iOS.

The error about non-modular headers is still there, when trying to use the code from Swift files.
There's a blog post, which explains non-modular headers issue in cocoapods, under the section "Common Header Pitfalls": http://blog.cocoapods.org/Pod-Authors-Guide-to-CocoaPods-Frameworks/

This problem doesn't appear with Objective C, but does happen in Swift, because swift has a different treatment of modules as well as header files. So when an existing project in Swift gets integrated with react-native and react-native-branch, using cocoapods, the problem above prevents the Swift code from accessing 
RNBranch code, necessary for the initialization under iOS.
