### PR TITLE
expose email subject for share sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Control parameters for the link.
 | ------------------ | -------- | --------------------
 | messageHeader      | `string` | The header text
 | messageBody        | `string` | The body text
+| emailSubject       | `string` | The subject of the email channel if selected
 
 ## Referral Methods
 ######  <a id='loadrewards'></a>[loadRewards()](#loadrewards)

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -172,7 +172,13 @@ RCT_EXPORT_METHOD(
 ){
   dispatch_async(dispatch_get_main_queue(), ^(void){
     BranchUniversalObject *branchUniversalObject = [self createBranchUniversalObject:branchUniversalObjectMap];
-    BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:controlParamsMap];
+    
+    NSMutableDictionary *mutableControlParams = [controlParamsMap mutableCopy];
+    if (shareOptionsMap && [shareOptionsMap objectForKey:@"emailSubject"]) {
+        [mutableControlParams setValue:[shareOptionsMap objectForKey:@"emailSubject"] forKey:@"$email_subject"];
+    }
+      
+    BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:mutableControlParams];
 
     UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
     UIViewController *fromViewController = (rootViewController.presentedViewController ? rootViewController.presentedViewController : rootViewController);


### PR DESCRIPTION
@rt2zz This was [requested on the core library](https://github.com/BranchMetrics/ios-branch-deep-linking/issues/383) and I had forgotten we already do expose it. This makes the interface a bit more consistent