### PR TITLE
complete switch to RCTEventEmitter.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,7 @@
-import { NativeModules, NativeAppEventEmitter, DeviceEventEmitter, Platform } from 'react-native'
+import { NativeModules, NativeEventEmitter } from 'react-native'
 
-// According to the React Native docs from 0.21, NativeAppEventEmitter is used for native iOS modules to emit events. DeviceEventEmitter is used for native Android modules.
-// Both are technically supported on Android -- but I chose to follow the suggested route by the documentation to minimize the risk of this code breaking with a future release
-// in case NativeAppEventEmitter ever got deprecated on Android
-const nativeEventEmitter = Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter
 const { RNBranch } = NativeModules
+const branchEventEmitter = new NativeEventEmitter(RNBranch)
 
 import createBranchUniversalObject from './branchUniversalObject'
 
@@ -20,8 +17,8 @@ class Branch {
 
   constructor() {
     // listen for initSession results and errors.
-    nativeEventEmitter.addListener(INIT_SESSION_SUCCESS, this._onInitSessionResult)
-    nativeEventEmitter.addListener(INIT_SESSION_ERROR, this._onInitSessionResult)
+    branchEventEmitter.addListener(INIT_SESSION_SUCCESS, this._onInitSessionResult)
+    branchEventEmitter.addListener(INIT_SESSION_ERROR, this._onInitSessionResult)
 
     this._processInitSession()
   }


### PR DESCRIPTION
this module's event emitting is currently broken on latest versions of react (only tested with 0.30+, can't say for previous versions)

unfortunately the [documentation](http://facebook.github.io/react-native/docs/native-modules-ios.html#sending-events-to-javascript) isn't up to date but my understanding is that [events should no longer be emitted on the global bus](https://github.com/facebook/react-native/blob/v0.30.0/Libraries/EventEmitter/RCTNativeAppEventEmitter.js#L17-L20) and that native modules should now use a subclassed/module-scopped `NativeEventEmitter` as can be seen [here](https://github.com/facebook/react-native/commit/b71db1155440ec433dcf51b54c015166ecca8732) and [there](https://github.com/facebook/react-native/commit/1623e34c5135fc50d67272c30c123426d4b0036d)

the recent [switch to RCTEventEmitter](https://github.com/BranchMetrics/react-native-branch-deep-linking/commit/de69943420c0c25e180a2024a60d624f23df0e80) only affected the native code. so the current js code was listening on the global bus while the native code was sending events on the RNBranch-scopped bus... this pull request updates the js code to listen on that scopped bus.

cc @nicklockwood (sorry for blindly cc'ing you in here, but i would appreciate if you could confirm this is indeed the new/correct way of communicating via events.)