### PR TITLE
Update Event Emitter

### DIFF
--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -1,10 +1,3 @@
-//
-//  RNBranch.h
-//  RNBranch
-//
-//  Created by Kevin Stumpf on 1/28/16.
-//
-
 #import <Foundation/Foundation.h>
 #import "RCTEventEmitter.h"
 

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -1,17 +1,10 @@
-//
-//  RNBranch.m
-//  RNBranch
-//
-//  Created by Kevin Stumpf on 1/28/16.
-//
-
 #import "RNBranch.h"
 #import "RCTBridgeModule.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
 #import <Branch/Branch.h>
-#import "BranchLinkProperties.h"
-#import "BranchUniversalObject.h"
+#import <Branch/BranchLinkProperties.h>
+#import <Branch/BranchUniversalObject.h>
 
 @implementation RNBranch
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "react-native": "^0.30.0",
-    "react-native-mock": "0.0.7"
+    "react-native-mock": "^0.2.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "files": ["src", "docs", "android", "ios", "react-native-branch.podspec"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "files": ["src", "docs", "android", "ios", "react-native-branch.podspec"],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,13 @@
   "version": "0.4.1",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
-  "files": ["src", "docs", "android", "ios", "react-native-branch.podspec"],
+  "files": [
+    "src",
+    "docs",
+    "android",
+    "ios",
+    "react-native-branch.podspec"
+  ],
   "scripts": {
     "test": "ava"
   },
@@ -34,8 +40,8 @@
     "link"
   ],
   "authors": [
-      "Zack Story <zack@root-two.com> (https://github.com/rt2zz)",
-      "Kevin Stumpf (https://github.com/kevinstumpf)"
+    "Zack Story <zack@root-two.com> (https://github.com/rt2zz)",
+    "Kevin Stumpf (https://github.com/kevinstumpf)"
   ],
   "license": "MIT",
   "repository": {
@@ -54,7 +60,7 @@
     "eslint-config-rackt": "^1.1.1",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
-    "react-native": "^0.24.1",
+    "react-native": "^0.30.0",
     "react-native-mock": "0.0.7"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,7 @@
-import { NativeModules, NativeAppEventEmitter, DeviceEventEmitter, Platform } from 'react-native'
+import { NativeModules, NativeEventEmitter, DeviceEventEmitter, Platform } from 'react-native'
 
-// According to the React Native docs from 0.21, NativeAppEventEmitter is used for native iOS modules to emit events. DeviceEventEmitter is used for native Android modules.
-// Both are technically supported on Android -- but I chose to follow the suggested route by the documentation to minimize the risk of this code breaking with a future release
-// in case NativeAppEventEmitter ever got deprecated on Android
-const nativeEventEmitter = Platform.OS === 'ios' ? NativeAppEventEmitter : DeviceEventEmitter
 const { RNBranch } = NativeModules
+const nativeEventEmitter = Platform.OS === 'ios' ? new NativeEventEmitter(RNBranch) : DeviceEventEmitter
 
 import createBranchUniversalObject from './branchUniversalObject'
 


### PR DESCRIPTION
**background** the move to stay in line with react-native 0.30 was premature and broke implementation for people stuck on pre 0.28. Instead we will wait until the old event emitter usage is fully deprecated before making the switch.

Leaving this PR open as a reminder and to track progress.