### PR TITLE
Adding environment switch for iOS (to use the test key instead of the live one)

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -9,6 +9,8 @@ After [installing](./installation.md) branch, you will need to set up your andro
     // Initialize the Branch Session at the top of existing didFinishLaunchingWithOptions
     - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
     {
+      // Uncomment this line to use the test key instead of the live one.
+      // [RNBranch useTestInstance]
       [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES]; // <-- add this
 
       NSURL *jsCodeLocation;

--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -6,5 +6,6 @@
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable;
 + (BOOL)handleDeepLink:(NSURL *)url;
 + (BOOL)continueUserActivity:(NSUserActivity *)userActivity;
++ (void)useTestInstance;
 
 @end

--- a/testbed/ios/testbed/AppDelegate.m
+++ b/testbed/ios/testbed/AppDelegate.m
@@ -17,6 +17,11 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
+  /**
+   * Uncomment to use the test key instead of the live one.
+   */
+//   [RNBranch useTestInstance]
+
   [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
 
   NSURL *jsCodeLocation;


### PR DESCRIPTION
The purpose of this PR is to allow users to switch from live to test programatically. For this to work, `branch_key` needs to be a dict with both `live` and `test` keys set.

This would be typically used with a compile-time environment switch of some sort:

```objc
if ([env isEqualToString:@"DEV"]) {
  [RNBranch useTestInstance];
}
[RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
```