### PR TITLE
Add support for installation via Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ If you are new to react-native or cocoa-pods, read below for more details:
 - [If you already have React in your Podfile](./docs/installation.md#pod-only-installation)
 - [If you do not know what a Podfile is](./docs/installation.md#creating-a-new-podfile)
 
+### Carthage
+[carthage]: https://github.com/Carthage/Carthage
+
+If you would prefer to use [Carthage](carthage), you can skip steps 3 & 4 above and instead add the following to your `Cartfile`:
+
+`github "BranchMetrics/ios-branch-deep-linking`
+
+Then run:
+
+`$ carthage bootstrap`
+
+If you're unfamiliar with how to add a framework to your project with [Carthage](carthage), you can [learn more here](https://github.com/Carthage/Carthage#adding-frameworks-to-an-application). You will need to maually link the framework by adding it to the "Linked Frameworks and Libraries" section of your target settings, and copy it by adding it to the "Input Files" section of your `carthage copy-frameworks` build phase.
+
 ## Next Steps
 In order to get full branch support you will need to setup your ios and android projects accordingly:
 - [iOS](./docs/setup.md#ios)

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -222,12 +222,14 @@
 		B3A3CC401C5B0A070016AC52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/Build/iOS";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public\"",
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public/Branch\"",
+					"\"$(SRCROOT)/../../../ios/Carthage/Build/iOS/Branch.framework/Headers\"",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -242,12 +244,14 @@
 		B3A3CC411C5B0A070016AC52 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/Build/iOS";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**",
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public\"",
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public/Branch\"",
+					"\"$(SRCROOT)/../../../ios/Carthage/Build/iOS/Branch.framework/Headers\"",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Thanks for this framework!

This PR adds support to be able to install the framework via the [Carthage](https://github.com/Carthage/Carthage) dependency manager.

Essentially, it's just adding the `Carthage` build directory to the target's Framework Search Paths, and adding the framework's `Headers` directory to the target's Header Search Paths. Neither of these changes should have any affect on existing and future CocoaPods integrations, just as including the `Pods` directories in Framework/Header search paths has no affect on Carthage integrations.

I have tested this fork on a private project, and it installs and builds just fine, but feel free to do your own testing.