### PR TITLE
Fixes "'Branch/Branch.h' not found" errors.

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -2,7 +2,7 @@
 #import "RCTBridgeModule.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
-#import <Branch/Branch.h>
+#import "Branch.h"
 #import "BranchLinkProperties.h"
 #import "BranchUniversalObject.h"
 

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public\"",
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public/Branch\"",
 					"\"$(SRCROOT)/../../../ios/Carthage/Build/iOS/Branch.framework/Headers\"",
+					"\"$(SRCROOT)/../../../ios/Pods/Branch/**",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -252,6 +253,7 @@
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public\"",
 					"\"$(SRCROOT)/../../../ios/Pods/Headers/Public/Branch\"",
 					"\"$(SRCROOT)/../../../ios/Carthage/Build/iOS/Branch.framework/Headers\"",
+					"\"$(SRCROOT)/../../../ios/Pods/Branch/**",
 				);
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This fixes issues when Branch is installed via cocoapods, when React Native is *not* installed via cocoapods.

See issues:
https://github.com/BranchMetrics/react-native-branch-deep-linking/issues/60,  https://github.com/BranchMetrics/react-native-branch-deep-linking/issues/18 for more information.  The final solution by @Morhaus is hard to maintain, as RNBranch.m needs to be adjusted after each fresh `npm install`.

Because `Branch.h` in `Pods` is actually under `Branch-SDK`, `Branch/Branch.h`. Thus just importing `"Branch.h"` works well with my configuration, given the `HEADER_SEARCH_PATHS` in this PR. However, I haven't verified in the case where both React and branch are installed via cocoapods.

It seems like the `HEADER_SEARCH_PATHS` entry `$(SRCROOT)/../../../ios/Pods/Headers/Public/Branch` **should have** solved this problem, but after `pod install` with the latest versions of `cocoapods` and `Branch`, there aren't any Header files that I find in that `/Headers` directory, so it doesn't seem to help.