### PR TITLE
Subscribe cache TTL (0.9.1)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,9 @@ import createBranchUniversalObject from './branchUniversalObject'
 
 const INIT_SESSION_SUCCESS = 'RNBranch.initSessionSuccess'
 const INIT_SESSION_ERROR = 'RNBranch.initSessionError'
+const INIT_SESSION_TTL = 5000
 
 class Branch {
-  initSessionTTL = 5000;
-
   _launchTime = new Date().getTime();
   _initSessionResult = null;
   _lastParams = null;
@@ -33,7 +32,7 @@ class Branch {
     // void cache after TTL expires
     setTimeout(() => {
       this._initSessionResult = null
-    }, this.initSessionTTL)
+    }, INIT_SESSION_TTL)
   }
 
   /*** RNBranch Deep Linking ***/
@@ -48,7 +47,7 @@ class Branch {
     RNBranch.redeemInitSessionResult()
 
     // Cache up to the TTL
-    if (this._timeSinceLaunch() < this.initSessionTTL) {
+    if (this._timeSinceLaunch() < INIT_SESSION_TTL) {
       this._initSessionResult = result
     }
 


### PR DESCRIPTION
Added a 5 s TTL for the cache. Any callback to a `subscribe` call made at initialization will receive a link that launched the app. Subsequent calls to subscribe, after the TTL has expired, will not receive a cached link. This should address #73. This will be part of the 0.9.1 release.

It would be nice to make the TTL configurable, which was the intention in the first commit, but the `setTimeout()` call in the constructor happens before a caller can set the property value. This can be done without a timeout or using other means. For now, INIT_SESSION_TTL is a constant. The idea was not to encourage users to configure it but to provide a workaround in case the default value doesn't work in some situation. This can still be added one way or another.