### PR TITLE
Additional link properties (0.9)

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -265,6 +265,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     if (linkPropertiesMap.hasKey("alias")) linkProperties.setFeature(linkPropertiesMap.getString("alias"));
     if (linkPropertiesMap.hasKey("campaign")) linkProperties.setFeature(linkPropertiesMap.getString("campaign"));
     if (linkPropertiesMap.hasKey("channel")) linkProperties.setChannel(linkPropertiesMap.getString("channel"));
+    if (linkPropertiesMap.hasKey("duration")) linkProperties.setDuration(linkPropertiesMap.getInt("duration"));
     if (linkPropertiesMap.hasKey("feature")) linkProperties.setFeature(linkPropertiesMap.getString("feature"));
     if (linkPropertiesMap.hasKey("stage")) linkProperties.setFeature(linkPropertiesMap.getString("stage"));
     if (linkPropertiesMap.hasKey("tags")) {

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -265,7 +265,6 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     if (linkPropertiesMap.hasKey("alias")) linkProperties.setFeature(linkPropertiesMap.getString("alias"));
     if (linkPropertiesMap.hasKey("campaign")) linkProperties.setFeature(linkPropertiesMap.getString("campaign"));
     if (linkPropertiesMap.hasKey("channel")) linkProperties.setChannel(linkPropertiesMap.getString("channel"));
-    if (linkPropertiesMap.hasKey("duration")) linkProperties.setDuration(linkPropertiesMap.getInt("duration"));
     if (linkPropertiesMap.hasKey("feature")) linkProperties.setFeature(linkPropertiesMap.getString("feature"));
     if (linkPropertiesMap.hasKey("stage")) linkProperties.setFeature(linkPropertiesMap.getString("stage"));
     if (linkPropertiesMap.hasKey("tags")) {

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -262,8 +262,18 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
   public static LinkProperties createLinkProperties(ReadableMap linkPropertiesMap, @Nullable ReadableMap controlParams){
     LinkProperties linkProperties = new LinkProperties();
+    if (linkPropertiesMap.hasKey("alias")) linkProperties.setFeature(linkPropertiesMap.getString("alias"));
+    if (linkPropertiesMap.hasKey("campaign")) linkProperties.setFeature(linkPropertiesMap.getString("campaign"));
     if (linkPropertiesMap.hasKey("channel")) linkProperties.setChannel(linkPropertiesMap.getString("channel"));
     if (linkPropertiesMap.hasKey("feature")) linkProperties.setFeature(linkPropertiesMap.getString("feature"));
+    if (linkPropertiesMap.hasKey("stage")) linkProperties.setFeature(linkPropertiesMap.getString("stage"));
+    if (linkPropertiesMap.hasKey("tags")) {
+      ReadableArray tags = linkPropertiesMap.getArray("tags");
+      for (int i=0; i<tags.size(); ++i) {
+        String tag = tags.getString(i);
+        linkProperties.addTag(tag);
+      }
+    }
 
     if (controlParams != null) {
       if (controlParams.hasKey("$fallback_url")) {

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -101,12 +101,31 @@ RCT_EXPORT_MODULE();
 - (BranchLinkProperties*) createLinkProperties:(NSDictionary *)linkPropertiesMap withControlParams:(NSDictionary *)controlParamsMap
 {
     BranchLinkProperties *linkProperties = [[BranchLinkProperties alloc] init];
-    linkProperties.alias    = linkPropertiesMap[@"alias"];
-    linkProperties.campaign = linkPropertiesMap[@"campaign"];
-    linkProperties.channel  = linkPropertiesMap[@"channel"];
-    linkProperties.feature  = linkPropertiesMap[@"feature"];
-    linkProperties.stage    = linkPropertiesMap[@"stage"];
-    linkProperties.tags     = [NSSet setWithArray:linkPropertiesMap[@"tags"]];
+
+    if (linkPropertiesMap[@"alias"]) {
+        linkProperties.alias = linkPropertiesMap[@"alias"];
+    }
+
+    if (linkPropertiesMap[@"campaign"]) {
+        linkProperties.campaign = linkPropertiesMap[@"campaign"];
+    }
+
+    if (linkPropertiesMap[@"channel"]) {
+        linkProperties.channel = linkPropertiesMap[@"channel"];
+    }
+
+    if (linkPropertiesMap[@"feature"]) {
+        linkProperties.feature = linkPropertiesMap[@"feature"];
+    }
+
+    if (linkPropertiesMap[@"stage"]) {
+        linkProperties.stage = linkPropertiesMap[@"stage"];
+    }
+
+    if (linkPropertiesMap[@"tags"]) {
+        linkProperties.tags = linkPropertiesMap[@"tags"];
+    }
+
     linkProperties.controlParams = controlParamsMap;
     return linkProperties;
 }
@@ -169,7 +188,7 @@ RCT_EXPORT_METHOD(
     dispatch_async(dispatch_get_main_queue(), ^(void){
         BranchUniversalObject *branchUniversalObject = [self createBranchUniversalObject:branchUniversalObjectMap];
         
-        NSMutableDictionary *mutableControlParams = [controlParamsMap mutableCopy];
+        NSMutableDictionary *mutableControlParams = controlParamsMap.mutableCopy;
         if (shareOptionsMap && shareOptionsMap[@"emailSubject"]) {
             mutableControlParams[@"$email_subject"] = shareOptionsMap[@"emailSubject"];
         }
@@ -184,7 +203,7 @@ RCT_EXPORT_METHOD(
                                                      completion:^(NSString *activityType, BOOL completed){
                                                          NSDictionary *result = @{
                                                                                   @"channel" : activityType ?: [NSNull null],
-                                                                                  @"completed" : [NSNumber numberWithBool:completed],
+                                                                                  @"completed" : @(completed),
                                                                                   @"error" : [NSNull null]
                                                                                   };
                                                          
@@ -220,16 +239,8 @@ RCT_EXPORT_METHOD(
     
     [branchUniversalObject getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
         if (!error) {
-            NSError *err;
-            NSDictionary *jsonObj = @{ @"url": url, @"options": @0, @"error": err };
-            
-            if (err) {
-                NSLog(@"Parsing Error: %@", err.localizedDescription);
-                reject([NSString stringWithFormat: @"%lu", (long)err.code], err.localizedDescription, err);
-            } else {
-                NSLog(@"RNBranch Success");
-                resolve(jsonObj);
-            }
+            NSLog(@"RNBranch Success");
+            resolve(@{ @"url": url });
         } else {
             reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
         }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -104,6 +104,10 @@ RCT_EXPORT_MODULE();
     linkProperties.alias    = linkPropertiesMap[@"alias"];
     linkProperties.campaign = linkPropertiesMap[@"campaign"];
     linkProperties.channel  = linkPropertiesMap[@"channel"];
+    NSNumber *duration      = linkPropertiesMap[@"duration"];
+    if (duration) {
+        linkProperties.matchDuration = duration.unsignedIntegerValue;
+    }
     linkProperties.feature  = linkPropertiesMap[@"feature"];
     linkProperties.stage    = linkPropertiesMap[@"stage"];
     linkProperties.tags     = [NSSet setWithArray:linkPropertiesMap[@"tags"]];

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -101,8 +101,12 @@ RCT_EXPORT_MODULE();
 - (BranchLinkProperties*) createLinkProperties:(NSDictionary *)linkPropertiesMap withControlParams:(NSDictionary *)controlParamsMap
 {
     BranchLinkProperties *linkProperties = [[BranchLinkProperties alloc] init];
-    linkProperties.channel = linkPropertiesMap[@"channel"];
-    linkProperties.feature = linkPropertiesMap[@"feature"];
+    linkProperties.alias    = linkPropertiesMap[@"alias"];
+    linkProperties.campaign = linkPropertiesMap[@"campaign"];
+    linkProperties.channel  = linkPropertiesMap[@"channel"];
+    linkProperties.feature  = linkPropertiesMap[@"feature"];
+    linkProperties.stage    = linkPropertiesMap[@"stage"];
+    linkProperties.tags     = [NSSet setWithArray:linkPropertiesMap[@"tags"]];
     linkProperties.controlParams = controlParamsMap;
     return linkProperties;
 }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -104,10 +104,6 @@ RCT_EXPORT_MODULE();
     linkProperties.alias    = linkPropertiesMap[@"alias"];
     linkProperties.campaign = linkPropertiesMap[@"campaign"];
     linkProperties.channel  = linkPropertiesMap[@"channel"];
-    NSNumber *duration      = linkPropertiesMap[@"duration"];
-    if (duration) {
-        linkProperties.matchDuration = duration.unsignedIntegerValue;
-    }
     linkProperties.feature  = linkPropertiesMap[@"feature"];
     linkProperties.stage    = linkPropertiesMap[@"stage"];
     linkProperties.tags     = [NSSet setWithArray:linkPropertiesMap[@"tags"]];


### PR DESCRIPTION
Added support for the following link properties to address #84:

- alias
- campaign
- stage
- tags

e.g.:

```js
let linkProperties = { feature: 'share', channel: 'RNApp', alias: 'get', campaign: 'launch', stage: 'level 1', tags: [ 'tag_1', 'tag_2' ] }
```