### PR TITLE
Portability 0.9 (iOS)

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -267,6 +267,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     if (linkPropertiesMap.hasKey("channel")) linkProperties.setChannel(linkPropertiesMap.getString("channel"));
     if (linkPropertiesMap.hasKey("feature")) linkProperties.setFeature(linkPropertiesMap.getString("feature"));
     if (linkPropertiesMap.hasKey("stage")) linkProperties.setFeature(linkPropertiesMap.getString("stage"));
+
     if (linkPropertiesMap.hasKey("tags")) {
       ReadableArray tags = linkPropertiesMap.getArray("tags");
       for (int i=0; i<tags.size(); ++i) {
@@ -276,29 +277,11 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     if (controlParams != null) {
-      if (controlParams.hasKey("$fallback_url")) {
-        linkProperties.addControlParameter("$fallback_url", controlParams.getString("$fallback_url"));
-      }
-      if (controlParams.hasKey("$desktop_url")) {
-        linkProperties.addControlParameter("$desktop_url", controlParams.getString("$desktop_url"));
-      }
-      if (controlParams.hasKey("$android_url")) {
-        linkProperties.addControlParameter("$android_url", controlParams.getString("$android_url"));
-      }
-      if (controlParams.hasKey("$ios_url")) {
-        linkProperties.addControlParameter("$ios_url", controlParams.getString("$ios_url"));
-      }
-      if (controlParams.hasKey("$ipad_url")) {
-        linkProperties.addControlParameter("$ipad_url", controlParams.getString("$ipad_url"));
-      }
-      if (controlParams.hasKey("$fire_url")) {
-        linkProperties.addControlParameter("$fire_url", controlParams.getString("$fire_url"));
-      }
-      if (controlParams.hasKey("$blackberry_url")) {
-        linkProperties.addControlParameter("$blackberry_url", controlParams.getString("$blackberry_url"));
-      }
-      if (controlParams.hasKey("$windows_phone_url")) {
-        linkProperties.addControlParameter("$windows_phone_url", controlParams.getString("$windows_phone_url"));
+      ReadableMapKeySetIterator iterator = controlParams.keySetIterator();
+      while (iterator.hasNextKey()) {
+        String key = iterator.nextKey();
+        Object value = getReadableMapObjectForKey(controlParams, key);
+        linkProperties.addControlParameter(key, value.toString());
       }
     }
 
@@ -310,8 +293,23 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
       .setCanonicalIdentifier(branchUniversalObjectMap.getString("canonicalIdentifier"));
 
     if (branchUniversalObjectMap.hasKey("title")) branchUniversalObject.setTitle(branchUniversalObjectMap.getString("title"));
+    if (branchUniversalObjectMap.hasKey("canonicalUrl")) branchUniversalObject.setCanonicalUrl(branchUniversalObjectMap.getString("canonicalUrl"));
     if (branchUniversalObjectMap.hasKey("contentDescription")) branchUniversalObject.setContentDescription(branchUniversalObjectMap.getString("contentDescription"));
     if (branchUniversalObjectMap.hasKey("contentImageUrl")) branchUniversalObject.setContentImageUrl(branchUniversalObjectMap.getString("contentImageUrl"));
+    if (branchUniversalObjectMap.hasKey("contentIndexingMode")) {
+      String mode = branchUniversalObjectMap.getString("contentIndexingMode");
+      switch (branchUniversalObjectMap.getType("contentIndexingMode")) {
+        case String:
+          if (mode.equals("private"))
+            branchUniversalObject.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PRIVATE);
+          else if (mode.equals("public"))
+            branchUniversalObject.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC);
+          else
+            Log.w(REACT_CLASS, "Unsupported value for contentIndexingMode: " + mode + ". Supported values are \"public\" and \"private\"");
+        default:
+          Log.w(REACT_CLASS, "contentIndexingMode must be a String");
+      }
+    }
 
     if(branchUniversalObjectMap.hasKey("metadata")) {
       ReadableMap metadataMap = branchUniversalObjectMap.getMap("metadata");

--- a/ios/BranchLinkProperties+RNBranch.h
+++ b/ios/BranchLinkProperties+RNBranch.h
@@ -14,5 +14,4 @@
 
 - (instancetype)initWithMap:(NSDictionary *)map;
 
-+ (NSDictionary<NSString *, RNBranchProperty *> *) supportedProperties;
 @end

--- a/ios/BranchLinkProperties+RNBranch.h
+++ b/ios/BranchLinkProperties+RNBranch.h
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import <Branch/Branch.h>

--- a/ios/BranchLinkProperties+RNBranch.h
+++ b/ios/BranchLinkProperties+RNBranch.h
@@ -8,8 +8,11 @@
 
 #import <Branch/Branch.h>
 
+@class RNBranchProperty;
+
 @interface BranchLinkProperties(RNBranch)
 
 - (instancetype)initWithMap:(NSDictionary *)map;
 
++ (NSDictionary<NSString *, RNBranchProperty *> *) supportedProperties;
 @end

--- a/ios/BranchLinkProperties+RNBranch.h
+++ b/ios/BranchLinkProperties+RNBranch.h
@@ -1,0 +1,15 @@
+//
+//  BranchLinkProperties+RNBranch.h
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import <Branch/Branch.h>
+
+@interface BranchLinkProperties(RNBranch)
+
+- (instancetype)initWithMap:(NSDictionary *)map;
+
+@end

--- a/ios/BranchLinkProperties+RNBranch.m
+++ b/ios/BranchLinkProperties+RNBranch.m
@@ -13,7 +13,7 @@
 
 - (instancetype)initWithMap:(NSDictionary *)map
 {
-    self = [super init];
+    self = [self init];
     if (self) {
         [RNBranchProperty setLinkPropertiesOn:self fromMap:map];
     }

--- a/ios/BranchLinkProperties+RNBranch.m
+++ b/ios/BranchLinkProperties+RNBranch.m
@@ -7,15 +7,36 @@
 //
 
 #import "BranchLinkProperties+RNBranch.h"
+#import "NSObject+RNBranch.h"
 #import "RNBranchProperty.h"
 
 @implementation BranchLinkProperties(RNBranch)
+
++ (NSDictionary<NSString *,RNBranchProperty *> *)supportedProperties
+{
+    static NSDictionary<NSString *, RNBranchProperty *> *_linkProperties;
+    static dispatch_once_t once = 0;
+    dispatch_once(&once, ^{
+        _linkProperties =
+        @{
+          @"alias": [RNBranchProperty propertyWithSetterSelector:@selector(setAlias:) type:NSString.class],
+          @"campaign": [RNBranchProperty propertyWithSetterSelector:@selector(setCampaign:) type:NSString.class],
+          @"channel": [RNBranchProperty propertyWithSetterSelector:@selector(setChannel:) type:NSString.class],
+          // @"duration": [RNBranchProperty propertyWithSetterSelector:@selector(setMatchDuration:) type:NSNumber.class], // deprecated
+          @"feature": [RNBranchProperty propertyWithSetterSelector:@selector(setFeature:) type:NSString.class],
+          @"stage": [RNBranchProperty propertyWithSetterSelector:@selector(setStage:) type:NSString.class],
+          @"tags": [RNBranchProperty propertyWithSetterSelector:@selector(setTags:) type:NSArray.class]
+          };
+    });
+    
+    return _linkProperties;
+}
 
 - (instancetype)initWithMap:(NSDictionary *)map
 {
     self = [self init];
     if (self) {
-        [RNBranchProperty setLinkPropertiesOn:self fromMap:map];
+        [self setSupportedPropertiesWithMap:map];
     }
     return self;
 }

--- a/ios/BranchLinkProperties+RNBranch.m
+++ b/ios/BranchLinkProperties+RNBranch.m
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import "BranchLinkProperties+RNBranch.h"

--- a/ios/BranchLinkProperties+RNBranch.m
+++ b/ios/BranchLinkProperties+RNBranch.m
@@ -1,0 +1,23 @@
+//
+//  BranchLinkProperties+RNBranch.m
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import "BranchLinkProperties+RNBranch.h"
+#import "RNBranchProperty.h"
+
+@implementation BranchLinkProperties(RNBranch)
+
+- (instancetype)initWithMap:(NSDictionary *)map
+{
+    self = [super init];
+    if (self) {
+        [RNBranchProperty setLinkPropertiesOn:self fromMap:map];
+    }
+    return self;
+}
+
+@end

--- a/ios/BranchUniversalObject+RNBranch.h
+++ b/ios/BranchUniversalObject+RNBranch.h
@@ -8,10 +8,14 @@
 
 #import <Branch/Branch.h>
 
+@class RNBranchProperty;
+
 @interface BranchUniversalObject(RNBranch)
 
 - (void)setContentIndexingMode:(NSString *)contentIndexingMode;
 
 - (instancetype)initWithMap:(NSDictionary *)map;
+
++ (NSDictionary<NSString *, RNBranchProperty *> *)supportedProperties;
 
 @end

--- a/ios/BranchUniversalObject+RNBranch.h
+++ b/ios/BranchUniversalObject+RNBranch.h
@@ -1,0 +1,17 @@
+//
+//  BranchUniversalObject+RNBranch.h
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import <Branch/Branch.h>
+
+@interface BranchUniversalObject(RNBranch)
+
+- (void)setContentIndexingMode:(NSString *)contentIndexingMode;
+
+- (instancetype)initWithMap:(NSDictionary *)map;
+
+@end

--- a/ios/BranchUniversalObject+RNBranch.h
+++ b/ios/BranchUniversalObject+RNBranch.h
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import <Branch/Branch.h>

--- a/ios/BranchUniversalObject+RNBranch.h
+++ b/ios/BranchUniversalObject+RNBranch.h
@@ -16,6 +16,4 @@
 
 - (instancetype)initWithMap:(NSDictionary *)map;
 
-+ (NSDictionary<NSString *, RNBranchProperty *> *)supportedProperties;
-
 @end

--- a/ios/BranchUniversalObject+RNBranch.m
+++ b/ios/BranchUniversalObject+RNBranch.m
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import "RCTLog.h"

--- a/ios/BranchUniversalObject+RNBranch.m
+++ b/ios/BranchUniversalObject+RNBranch.m
@@ -9,9 +9,29 @@
 #import "RCTLog.h"
 
 #import "BranchUniversalObject+RNBranch.h"
+#import "NSObject+RNBranch.h"
 #import "RNBranchProperty.h"
 
 @implementation BranchUniversalObject(RNBranch)
+
++ (NSDictionary<NSString *,RNBranchProperty *> *)supportedProperties
+{
+    static NSDictionary<NSString *, RNBranchProperty *> *_universalObjectProperties;
+    static dispatch_once_t once = 0;
+    dispatch_once(&once, ^{
+        _universalObjectProperties =
+        @{
+          @"canonicalUrl": [RNBranchProperty propertyWithSetterSelector:@selector(setCanonicalUrl:) type:NSString.class],
+          @"contentDescription": [RNBranchProperty propertyWithSetterSelector:@selector(setContentDescription:) type:NSString.class],
+          @"contentImageUrl": [RNBranchProperty propertyWithSetterSelector:@selector(setImageUrl:) type:NSString.class],
+          @"contentIndexingMode": [RNBranchProperty propertyWithSetterSelector:@selector(setContentIndexingMode:) type:NSString.class],
+          @"metadata": [RNBranchProperty propertyWithSetterSelector:@selector(setMetadata:) type:NSDictionary.class],
+          @"title": [RNBranchProperty propertyWithSetterSelector:@selector(setTitle:) type:NSString.class]
+          };
+    });
+    
+    return _universalObjectProperties;
+}
 
 - (instancetype)initWithMap:(NSDictionary *)map
 {
@@ -21,7 +41,7 @@
 
     self = [self initWithCanonicalIdentifier:canonicalIdentifier];
     if (self) {
-        [RNBranchProperty setUniversalObjectPropertiesOn:self fromMap:mutableMap];
+        [self setSupportedPropertiesWithMap:mutableMap];
     }
     return self;
 }

--- a/ios/BranchUniversalObject+RNBranch.m
+++ b/ios/BranchUniversalObject+RNBranch.m
@@ -1,0 +1,44 @@
+//
+//  BranchUniversalObject+RNBranch.m
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import "BranchUniversalObject+RNBranch.h"
+#import "RNBranchProperty.h"
+
+@implementation BranchUniversalObject(RNBranch)
+
+- (instancetype)initWithMap:(NSDictionary *)map
+{
+    NSString *canonicalIdentifier = map[@"canonicalIdentifier"];
+    self = [self initWithCanonicalIdentifier:canonicalIdentifier];
+    if (self) {
+        [RNBranchProperty setUniversalObjectPropertiesOn:self fromMap:map];
+    }
+    return self;
+}
+
+- (void)setContentIndexingMode:(NSString *)contentIndexingMode
+{
+    SEL selector = @selector(setContentIndexMode:);
+
+    if (![self respondsToSelector:selector]) {
+        NSLog(@"\"contentIndexingMode\" is not supported by the installed version of the native Branch SDK for objects of type BranchUniversalObject. Please update to the current release using \"pod update\" or \"carthage update\".");
+        return;
+    }
+
+    if ([contentIndexingMode isEqualToString:@"private"]) {
+        [self performSelector:selector withObject:@(ContentIndexModePrivate)];
+    }
+    else if ([contentIndexingMode isEqualToString:@"public"]) {
+        [self performSelector:selector withObject:@(ContentIndexModePublic)];
+    }
+    else {
+        NSLog(@"Invalid value \"%@\" for \"contentIndexingMode\". Supported values are \"public\" and \"private\"", contentIndexingMode);
+    }
+}
+
+@end

--- a/ios/BranchUniversalObject+RNBranch.m
+++ b/ios/BranchUniversalObject+RNBranch.m
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Dispatcher. All rights reserved.
 //
 
+#import "RCTLog.h"
+
 #import "BranchUniversalObject+RNBranch.h"
 #import "RNBranchProperty.h"
 
@@ -14,9 +16,12 @@
 - (instancetype)initWithMap:(NSDictionary *)map
 {
     NSString *canonicalIdentifier = map[@"canonicalIdentifier"];
+    NSMutableDictionary *mutableMap = map.mutableCopy;
+    [mutableMap removeObjectForKey:@"canonicalIdentifier"];
+
     self = [self initWithCanonicalIdentifier:canonicalIdentifier];
     if (self) {
-        [RNBranchProperty setUniversalObjectPropertiesOn:self fromMap:map];
+        [RNBranchProperty setUniversalObjectPropertiesOn:self fromMap:mutableMap];
     }
     return self;
 }
@@ -26,7 +31,7 @@
     SEL selector = @selector(setContentIndexMode:);
 
     if (![self respondsToSelector:selector]) {
-        NSLog(@"\"contentIndexingMode\" is not supported by the installed version of the native Branch SDK for objects of type BranchUniversalObject. Please update to the current release using \"pod update\" or \"carthage update\".");
+        RCTLogWarn(@"\"contentIndexingMode\" is not supported by the installed version of the native Branch SDK for objects of type BranchUniversalObject. Please update to the current release using \"pod update\" or \"carthage update\".");
         return;
     }
 
@@ -37,7 +42,7 @@
         [self performSelector:selector withObject:@(ContentIndexModePublic)];
     }
     else {
-        NSLog(@"Invalid value \"%@\" for \"contentIndexingMode\". Supported values are \"public\" and \"private\"", contentIndexingMode);
+        RCTLogWarn(@"Invalid value \"%@\" for \"contentIndexingMode\". Supported values are \"public\" and \"private\".", contentIndexingMode);
     }
 }
 

--- a/ios/NSObject+RNBranch.h
+++ b/ios/NSObject+RNBranch.h
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import <Foundation/Foundation.h>

--- a/ios/NSObject+RNBranch.h
+++ b/ios/NSObject+RNBranch.h
@@ -1,0 +1,19 @@
+//
+//  NSObject+RNBranch.h
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class RNBranchProperty;
+
+@interface NSObject(RNBranch)
+
++ (NSDictionary<NSString *, RNBranchProperty *> *)supportedProperties;
+
+- (void)setSupportedPropertiesWithMap:(NSDictionary *)map;
+
+@end

--- a/ios/NSObject+RNBranch.m
+++ b/ios/NSObject+RNBranch.m
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import "RCTLog.h"

--- a/ios/NSObject+RNBranch.m
+++ b/ios/NSObject+RNBranch.m
@@ -1,0 +1,47 @@
+//
+//  NSObject+RNBranch.m
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import "RCTLog.h"
+
+#import "NSObject+RNBranch.h"
+#import "RNBranchProperty.h"
+
+@implementation NSObject(RNBranch)
+
++ (NSDictionary<NSString *,RNBranchProperty *> *)supportedProperties
+{
+    return @{};
+}
+
+- (void)setSupportedPropertiesWithMap:(NSDictionary *)map
+{
+    for (NSString *key in map.allKeys) {
+        RNBranchProperty *property = self.class.supportedProperties[key];
+        if (!property) {
+            RCTLogWarn(@"\"%@\" is not a supported property for %@.", key, NSStringFromClass(self.class));
+            continue;
+        }
+        
+        id value = map[key];
+        Class type = property.type;
+        if (![value isKindOfClass:type]) {
+            RCTLogWarn(@"\"%@\" requires a value of type %@.", key, NSStringFromClass(type));
+            continue;
+        }
+        
+        SEL setterSelector = property.setterSelector;
+        if (![self respondsToSelector:setterSelector]) {
+            RCTLogWarn(@"\"%@\" is not supported by the installed version of the native Branch SDK for objects of type %@. Please update to the current release using \"pod update\" or \"carthage update\".", key, NSStringFromClass(self.class));
+            continue;
+        }
+        
+        [self performSelector:setterSelector withObject:value];
+    }
+}
+
+@end

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -2,7 +2,6 @@
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
 #import "RCTLog.h"
-#import "RNBranchProperty.h"
 #import "BranchLinkProperties+RNBranch.h"
 #import "BranchUniversalObject+RNBranch.h"
 

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -39,13 +39,7 @@ RCT_EXPORT_MODULE();
     }
     [branchInstance setDebug];
     [branchInstance initSessionWithLaunchOptions:launchOptions isReferrable:isReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
-        NSString *errorMessage = [NSNull null];
-        // TODO: How can you get an NSError that doesn't respondToSelector localizedDescription?
-        if ([error respondsToSelector:@selector(localizedDescription)]) {
-            errorMessage = error.localizedDescription;
-        } else if (error) {
-            errorMessage = error;
-        }
+        NSString *errorMessage = error.localizedDescription;
         
         initSessionWithLaunchOptionsResult = @{
                                                @"params": params && params[@"~id"] ? params : [NSNull null],

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -4,6 +4,10 @@
 #import "RCTEventDispatcher.h"
 #import <Branch/Branch.h>
 
+@interface RNBranch()
+@property (nonatomic, readonly) UIViewController *currentViewController;
+@end
+
 @implementation RNBranch
 
 NSString * const initSessionWithLaunchOptionsFinishedEventName = @"initSessionWithLaunchOptionsFinished";
@@ -12,6 +16,15 @@ static NSString* sourceUrl;
 static Branch *branchInstance;
 
 @synthesize bridge = _bridge;
+
+- (UIViewController *)currentViewController
+{
+    UIViewController *current = [UIApplication sharedApplication].keyWindow.rootViewController;
+    while (current.presentedViewController && ![current.presentedViewController isKindOfClass:UIAlertController.class]) {
+        current = current.presentedViewController;
+    }
+    return current;
+}
 
 RCT_EXPORT_MODULE();
 
@@ -195,11 +208,9 @@ RCT_EXPORT_METHOD(
         
         BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:mutableControlParams];
         
-        UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
-        UIViewController *fromViewController = rootViewController.presentedViewController ?: rootViewController;
         [branchUniversalObject showShareSheetWithLinkProperties:linkProperties
                                                    andShareText:shareOptionsMap[@"messageBody"]
-                                             fromViewController:fromViewController
+                                             fromViewController:self.currentViewController
                                                      completion:^(NSString *activityType, BOOL completed){
                                                          NSDictionary *result = @{
                                                                                   @"channel" : activityType ?: [NSNull null],

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -1,6 +1,7 @@
 #import "RNBranch.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
+#import "RCTLog.h"
 #import "RNBranchProperty.h"
 #import "BranchLinkProperties+RNBranch.h"
 #import "BranchUniversalObject+RNBranch.h"
@@ -101,11 +102,6 @@ RCT_EXPORT_MODULE();
 - (BranchUniversalObject*) createBranchUniversalObject:(NSDictionary *)branchUniversalObjectMap
 {
     BranchUniversalObject *branchUniversalObject = [[BranchUniversalObject alloc] initWithMap:branchUniversalObjectMap];
-    
-    NSDictionary* metaData = branchUniversalObjectMap[@"metadata"];
-    for (NSString *metaDataKey in metaData.allKeys) {
-        [branchUniversalObject addMetadataKey:metaDataKey value:metaData[metaDataKey]];
-    }
     
     return branchUniversalObject;
 }
@@ -233,7 +229,7 @@ RCT_EXPORT_METHOD(
     
     [branchUniversalObject getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
         if (!error) {
-            NSLog(@"RNBranch Success");
+            RCTLogInfo(@"RNBranch Success");
             resolve(@{ @"url": url });
         } else {
             reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
@@ -275,7 +271,7 @@ RCT_EXPORT_METHOD(
                                  andStage:stage
                               andCallback:^(NSString *url, NSError *error) {
                                   if (error) {
-                                      NSLog(@"RNBranch::Error: %@", error.localizedDescription);
+                                      RCTLogError(@"RNBranch::Error: %@", error.localizedDescription);
                                       reject(@"RNBranch::Error", @"getShortURLWithParams", error);
                                   }
                                   resolve(url);
@@ -291,7 +287,7 @@ RCT_EXPORT_METHOD(
             int credits = (int)[branchInstance getCredits];
             resolve(@{@"credits": @(credits)});
         } else {
-            NSLog(@"Load Rewards Error: %@", error.localizedDescription);
+            RCTLogError(@"Load Rewards Error: %@", error.localizedDescription);
             reject(@"RNBranch::Error::loadRewardsWithCallback", @"loadRewardsWithCallback", error);
         }
     }];
@@ -308,7 +304,7 @@ RCT_EXPORT_METHOD(
             if (!error) {
                 resolve(@{@"changed": @(changed)});
             } else {
-                NSLog(@"Redeem Rewards Error: %@", error.localizedDescription);
+                RCTLogError(@"Redeem Rewards Error: %@", error.localizedDescription);
                 reject(@"RNBranch::Error::redeemRewards", error.localizedDescription, error);
             }
         }];
@@ -317,7 +313,7 @@ RCT_EXPORT_METHOD(
             if (!error) {
                 resolve(@{@"changed": @(changed)});
             } else {
-                NSLog(@"Redeem Rewards Error: %@", error.localizedDescription);
+                RCTLogError(@"Redeem Rewards Error: %@", error.localizedDescription);
                 reject(@"RNBranch::Error::redeemRewards", error.localizedDescription, error);
             }
         }];
@@ -332,7 +328,7 @@ RCT_EXPORT_METHOD(
         if (!error) {
             resolve(list);
         } else {
-            NSLog(@"Credit History Error: %@", error.localizedDescription);
+            RCTLogError(@"Credit History Error: %@", error.localizedDescription);
             reject(@"RNBranch::Error::getCreditHistory", error.localizedDescription, error);
         }
     }];

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -199,20 +199,20 @@ RCT_EXPORT_MODULE();
     for (NSString *key in map.allKeys) {
         RNBranchProperty *property = properties[key];
         if (!property) {
-            NSLog(@"%@ is not a supported link property.", key);
+            NSLog(@"\"%@\" is not a supported link property.", key);
             continue;
         }
         
         id value = map[key];
         Class type = property.type;
         if (![value isKindOfClass:type]) {
-            NSLog(@"%@ requires a value of type %@", key, NSStringFromClass(type));
+            NSLog(@"\"%@\" requires a value of type %@.", key, NSStringFromClass(type));
             continue;
         }
         
         SEL setterSelector = property.setterSelector;
         if (![object respondsToSelector:setterSelector]) {
-            NSLog(@"%@ is not supported by the native Branch SDK for object of type %@. Please update to the current release using \"pod update\" or \"carthage update\"", key, NSStringFromClass(object.class));
+            NSLog(@"\"%@\" is not supported by the installed version of the native Branch SDK for objects of type %@. Please update to the current release using \"pod update\" or \"carthage update\".", key, NSStringFromClass(object.class));
             continue;
         }
         

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -35,7 +35,6 @@ RCT_EXPORT_MODULE();
     if (!branchInstance) {
         branchInstance = [Branch getInstance];
     }
-    [branchInstance setDebug];
     [branchInstance initSessionWithLaunchOptions:launchOptions isReferrable:isReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
         NSString *errorMessage = error.localizedDescription;
         

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -117,7 +117,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0820;
-				ORGANIZATIONNAME = Dispatcher;
+				ORGANIZATIONNAME = "Branch Metrics";
 				TargetAttributes = {
 					B3A3CC351C5B0A070016AC52 = {
 						CreatedOnToolsVersion = 7.2;

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		148030EF1CCDF9FA004ABEA4 /* RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 148030EE1CCDF9FA004ABEA4 /* RNBranch.m */; };
+		7B13692A1E3AC9A5006E68C0 /* NSObject+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1369291E3AC9A5006E68C0 /* NSObject+RNBranch.m */; };
 		7B7198AB1E3A7C1400127009 /* RNBranchProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7198AA1E3A7C1400127009 /* RNBranchProperty.m */; };
 		7B7198B11E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7198B01E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m */; };
 		7B7198B41E3A80CA00127009 /* BranchLinkProperties+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7198B31E3A80CA00127009 /* BranchLinkProperties+RNBranch.m */; };
@@ -30,6 +31,8 @@
 		147052301CCDDA6000333C29 /* libBranch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libBranch.a; path = "Pods/../build/Debug-iphoneos/libBranch.a"; sourceTree = "<group>"; };
 		148030ED1CCDF9FA004ABEA4 /* RNBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranch.h; sourceTree = "<group>"; };
 		148030EE1CCDF9FA004ABEA4 /* RNBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranch.m; sourceTree = "<group>"; };
+		7B1369281E3AC9A5006E68C0 /* NSObject+RNBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSObject+RNBranch.h"; sourceTree = "<group>"; };
+		7B1369291E3AC9A5006E68C0 /* NSObject+RNBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+RNBranch.m"; sourceTree = "<group>"; };
 		7B7198A91E3A7C1400127009 /* RNBranchProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranchProperty.h; sourceTree = "<group>"; };
 		7B7198AA1E3A7C1400127009 /* RNBranchProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchProperty.m; sourceTree = "<group>"; };
 		7B7198AF1E3A7CDD00127009 /* BranchUniversalObject+RNBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BranchUniversalObject+RNBranch.h"; sourceTree = "<group>"; };
@@ -68,6 +71,8 @@
 				7B7198B31E3A80CA00127009 /* BranchLinkProperties+RNBranch.m */,
 				7B7198AF1E3A7CDD00127009 /* BranchUniversalObject+RNBranch.h */,
 				7B7198B01E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m */,
+				7B1369281E3AC9A5006E68C0 /* NSObject+RNBranch.h */,
+				7B1369291E3AC9A5006E68C0 /* NSObject+RNBranch.m */,
 				148030ED1CCDF9FA004ABEA4 /* RNBranch.h */,
 				148030EE1CCDF9FA004ABEA4 /* RNBranch.m */,
 				7B7198A91E3A7C1400127009 /* RNBranchProperty.h */,
@@ -143,6 +148,7 @@
 			files = (
 				7B7198B41E3A80CA00127009 /* BranchLinkProperties+RNBranch.m in Sources */,
 				7B7198AB1E3A7C1400127009 /* RNBranchProperty.m in Sources */,
+				7B13692A1E3AC9A5006E68C0 /* NSObject+RNBranch.m in Sources */,
 				7B7198B11E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m in Sources */,
 				148030EF1CCDF9FA004ABEA4 /* RNBranch.m in Sources */,
 			);

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		148030EF1CCDF9FA004ABEA4 /* RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 148030EE1CCDF9FA004ABEA4 /* RNBranch.m */; };
+		7B7198AB1E3A7C1400127009 /* RNBranchProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7198AA1E3A7C1400127009 /* RNBranchProperty.m */; };
+		7B7198B11E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7198B01E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m */; };
+		7B7198B41E3A80CA00127009 /* BranchLinkProperties+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7198B31E3A80CA00127009 /* BranchLinkProperties+RNBranch.m */; };
 		7BE30B841E2FE6B300F74378 /* Branch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BE30B831E2FE6B300F74378 /* Branch.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 /* End PBXBuildFile section */
 
@@ -27,6 +30,12 @@
 		147052301CCDDA6000333C29 /* libBranch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libBranch.a; path = "Pods/../build/Debug-iphoneos/libBranch.a"; sourceTree = "<group>"; };
 		148030ED1CCDF9FA004ABEA4 /* RNBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranch.h; sourceTree = "<group>"; };
 		148030EE1CCDF9FA004ABEA4 /* RNBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranch.m; sourceTree = "<group>"; };
+		7B7198A91E3A7C1400127009 /* RNBranchProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranchProperty.h; sourceTree = "<group>"; };
+		7B7198AA1E3A7C1400127009 /* RNBranchProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchProperty.m; sourceTree = "<group>"; };
+		7B7198AF1E3A7CDD00127009 /* BranchUniversalObject+RNBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BranchUniversalObject+RNBranch.h"; sourceTree = "<group>"; };
+		7B7198B01E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BranchUniversalObject+RNBranch.m"; sourceTree = "<group>"; };
+		7B7198B21E3A80CA00127009 /* BranchLinkProperties+RNBranch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "BranchLinkProperties+RNBranch.h"; sourceTree = "<group>"; };
+		7B7198B31E3A80CA00127009 /* BranchLinkProperties+RNBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "BranchLinkProperties+RNBranch.m"; sourceTree = "<group>"; };
 		7BE30B831E2FE6B300F74378 /* Branch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Branch.framework; path = ../../../ios/Carthage/Build/iOS/Branch.framework; sourceTree = "<group>"; };
 		B3A3CC361C5B0A070016AC52 /* libRNBranch.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNBranch.a; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -55,8 +64,14 @@
 		B3A3CC2D1C5B0A070016AC52 = {
 			isa = PBXGroup;
 			children = (
+				7B7198B21E3A80CA00127009 /* BranchLinkProperties+RNBranch.h */,
+				7B7198B31E3A80CA00127009 /* BranchLinkProperties+RNBranch.m */,
+				7B7198AF1E3A7CDD00127009 /* BranchUniversalObject+RNBranch.h */,
+				7B7198B01E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m */,
 				148030ED1CCDF9FA004ABEA4 /* RNBranch.h */,
 				148030EE1CCDF9FA004ABEA4 /* RNBranch.m */,
+				7B7198A91E3A7C1400127009 /* RNBranchProperty.h */,
+				7B7198AA1E3A7C1400127009 /* RNBranchProperty.m */,
 				B3A3CC371C5B0A070016AC52 /* Products */,
 				52D26142CFE0360516F8E1D2 /* Frameworks */,
 			);
@@ -126,6 +141,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B7198B41E3A80CA00127009 /* BranchLinkProperties+RNBranch.m in Sources */,
+				7B7198AB1E3A7C1400127009 /* RNBranchProperty.m in Sources */,
+				7B7198B11E3A7CDD00127009 /* BranchUniversalObject+RNBranch.m in Sources */,
 				148030EF1CCDF9FA004ABEA4 /* RNBranch.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/RNBranchProperty.h
+++ b/ios/RNBranchProperty.h
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import <Branch/Branch.h>

--- a/ios/RNBranchProperty.h
+++ b/ios/RNBranchProperty.h
@@ -1,0 +1,17 @@
+//
+//  RNBranchProperty.h
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import <Branch/Branch.h>
+
+/*
+ * Utility class to represent dynamically all supported JS properties on BranchUniversalObject and BranchLinkProperties.
+ */
+@interface RNBranchProperty : NSObject
++ (void)setLinkPropertiesOn:(BranchLinkProperties *)linkProperties fromMap:(NSDictionary *)map;
++ (void)setUniversalObjectPropertiesOn:(BranchUniversalObject *)universalObject fromMap:(NSDictionary *)map;
+@end

--- a/ios/RNBranchProperty.h
+++ b/ios/RNBranchProperty.h
@@ -12,6 +12,10 @@
  * Utility class to represent dynamically all supported JS properties on BranchUniversalObject and BranchLinkProperties.
  */
 @interface RNBranchProperty : NSObject
-+ (void)setLinkPropertiesOn:(BranchLinkProperties *)linkProperties fromMap:(NSDictionary *)map;
-+ (void)setUniversalObjectPropertiesOn:(BranchUniversalObject *)universalObject fromMap:(NSDictionary *)map;
+@property (nonatomic) SEL setterSelector;
+@property (nonatomic) Class type;
+
++ (instancetype) propertyWithSetterSelector:(SEL)selector type:(Class)type;
+
+- (instancetype) initWithSetterSelector:(SEL)selector type:(Class)type NS_DESIGNATED_INITIALIZER;
 @end

--- a/ios/RNBranchProperty.m
+++ b/ios/RNBranchProperty.m
@@ -93,7 +93,7 @@
     for (NSString *key in map.allKeys) {
         RNBranchProperty *property = properties[key];
         if (!property) {
-            NSLog(@"\"%@\" is not a supported link property.", key);
+            NSLog(@"\"%@\" is not a supported %@ property.", properties == self.linkProperties ? @"link" : @"universal object", key);
             continue;
         }
 

--- a/ios/RNBranchProperty.m
+++ b/ios/RNBranchProperty.m
@@ -3,7 +3,7 @@
 //  RNBranch
 //
 //  Created by Jimmy Dee on 1/26/17.
-//  Copyright © 2017 Dispatcher. All rights reserved.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
 #import "RNBranchProperty.h"

--- a/ios/RNBranchProperty.m
+++ b/ios/RNBranchProperty.m
@@ -11,70 +11,7 @@
 
 #import "RCTLog.h"
 
-@interface RNBranchProperty()
-@property (nonatomic) SEL setterSelector;
-@property (nonatomic) Class type;
-
-+ (void)setProperties:(NSDictionary<NSString *, RNBranchProperty *> *)properties onObject:(NSObject *)object fromMap:(NSDictionary *)map;
-
-+ (NSDictionary<NSString *, RNBranchProperty *> *)linkProperties;
-+ (NSDictionary<NSString *, RNBranchProperty *> *)universalObjectProperties;
-
-+ (instancetype) propertyWithSetterSelector:(SEL)selector type:(Class)type;
-
-- (instancetype) initWithSetterSelector:(SEL)selector type:(Class)type NS_DESIGNATED_INITIALIZER;
-@end
-
 @implementation RNBranchProperty
-
-+ (void)setLinkPropertiesOn:(BranchLinkProperties *)linkProperties fromMap:(NSDictionary *)map
-{
-    [self setProperties:self.linkProperties onObject:linkProperties fromMap:map];
-}
-
-+ (void)setUniversalObjectPropertiesOn:(BranchUniversalObject *)universalObject fromMap:(NSDictionary *)map
-{
-    [self setProperties:self.universalObjectProperties onObject:universalObject fromMap:map];
-}
-
-+ (NSDictionary<NSString *, RNBranchProperty *> *)linkProperties
-{
-    static NSDictionary<NSString *, RNBranchProperty *> *_linkProperties;
-    static dispatch_once_t once = 0;
-    dispatch_once(&once, ^{
-        _linkProperties =
-        @{
-          @"alias": [self propertyWithSetterSelector:@selector(setAlias:) type:NSString.class],
-          @"campaign": [self propertyWithSetterSelector:@selector(setCampaign:) type:NSString.class],
-          @"channel": [self propertyWithSetterSelector:@selector(setChannel:) type:NSString.class],
-          // @"duration": [self propertyWithSetterSelector:@selector(setMatchDuration:) type:NSNumber.class], // deprecated
-          @"feature": [self propertyWithSetterSelector:@selector(setFeature:) type:NSString.class],
-          @"stage": [self propertyWithSetterSelector:@selector(setStage:) type:NSString.class],
-          @"tags": [self propertyWithSetterSelector:@selector(setTags:) type:NSArray.class]
-          };
-    });
-
-    return _linkProperties;
-}
-
-+ (NSDictionary<NSString *,RNBranchProperty *> *)universalObjectProperties
-{
-    static NSDictionary<NSString *, RNBranchProperty *> *_universalObjectProperties;
-    static dispatch_once_t once = 0;
-    dispatch_once(&once, ^{
-        _universalObjectProperties =
-        @{
-          @"canonicalUrl": [self propertyWithSetterSelector:@selector(setCanonicalUrl:) type:NSString.class],
-          @"contentDescription": [self propertyWithSetterSelector:@selector(setContentDescription:) type:NSString.class],
-          @"contentImageUrl": [self propertyWithSetterSelector:@selector(setImageUrl:) type:NSString.class],
-          @"contentIndexingMode": [self propertyWithSetterSelector:@selector(setContentIndexingMode:) type:NSString.class],
-          @"metadata": [self propertyWithSetterSelector:@selector(setMetadata:) type:NSDictionary.class],
-          @"title": [self propertyWithSetterSelector:@selector(setTitle:) type:NSString.class]
-          };
-    });
-
-    return _universalObjectProperties;
-}
 
 + (instancetype)propertyWithSetterSelector:(SEL)selector type:(Class)type
 {
@@ -89,32 +26,6 @@
         _type = type;
     }
     return self;
-}
-
-+ (void)setProperties:(NSDictionary<NSString *, RNBranchProperty *> *)properties onObject:(NSObject *)object fromMap:(NSDictionary *)map
-{
-    for (NSString *key in map.allKeys) {
-        RNBranchProperty *property = properties[key];
-        if (!property) {
-            RCTLogWarn(@"\"%@\" is not a supported %@ property.", key, properties == self.linkProperties ? @"link" : @"universal object");
-            continue;
-        }
-
-        id value = map[key];
-        Class type = property.type;
-        if (![value isKindOfClass:type]) {
-            RCTLogWarn(@"\"%@\" requires a value of type %@.", key, NSStringFromClass(type));
-            continue;
-        }
-
-        SEL setterSelector = property.setterSelector;
-        if (![object respondsToSelector:setterSelector]) {
-            RCTLogWarn(@"\"%@\" is not supported by the installed version of the native Branch SDK for objects of type %@. Please update to the current release using \"pod update\" or \"carthage update\".", key, NSStringFromClass(object.class));
-            continue;
-        }
-
-        [object performSelector:setterSelector withObject:value];
-    }
 }
 
 @end

--- a/ios/RNBranchProperty.m
+++ b/ios/RNBranchProperty.m
@@ -38,18 +38,19 @@
 + (NSDictionary<NSString *, RNBranchProperty *> *)linkProperties
 {
     static NSDictionary<NSString *, RNBranchProperty *> *_linkProperties;
-    if (_linkProperties) return _linkProperties;
-
-    _linkProperties =
-    @{
-      @"alias": [self propertyWithSetterSelector:@selector(setAlias:) type:NSString.class],
-      @"campaign": [self propertyWithSetterSelector:@selector(setCampaign:) type:NSString.class],
-      @"channel": [self propertyWithSetterSelector:@selector(setChannel:) type:NSString.class],
-      // @"duration": [self propertyWithSetterSelector:@selector(setMatchDuration:) type:NSNumber.class], // deprecated
-      @"feature": [self propertyWithSetterSelector:@selector(setFeature:) type:NSString.class],
-      @"stage": [self propertyWithSetterSelector:@selector(setStage:) type:NSString.class],
-      @"tags": [self propertyWithSetterSelector:@selector(setTags:) type:NSArray.class]
-      };
+    static dispatch_once_t once = 0;
+    dispatch_once(&once, ^{
+        _linkProperties =
+        @{
+          @"alias": [self propertyWithSetterSelector:@selector(setAlias:) type:NSString.class],
+          @"campaign": [self propertyWithSetterSelector:@selector(setCampaign:) type:NSString.class],
+          @"channel": [self propertyWithSetterSelector:@selector(setChannel:) type:NSString.class],
+          // @"duration": [self propertyWithSetterSelector:@selector(setMatchDuration:) type:NSNumber.class], // deprecated
+          @"feature": [self propertyWithSetterSelector:@selector(setFeature:) type:NSString.class],
+          @"stage": [self propertyWithSetterSelector:@selector(setStage:) type:NSString.class],
+          @"tags": [self propertyWithSetterSelector:@selector(setTags:) type:NSArray.class]
+          };
+    });
 
     return _linkProperties;
 }
@@ -57,16 +58,17 @@
 + (NSDictionary<NSString *,RNBranchProperty *> *)universalObjectProperties
 {
     static NSDictionary<NSString *, RNBranchProperty *> *_universalObjectProperties;
-    if (!_universalObjectProperties) return _universalObjectProperties;
-
-    _universalObjectProperties =
-    @{
-      @"canonicalUrl": [self propertyWithSetterSelector:@selector(setCanonicalUrl:) type:NSString.class],
-      @"contentDescription": [self propertyWithSetterSelector:@selector(setContentDescription:) type:NSString.class],
-      @"contentImageUrl": [self propertyWithSetterSelector:@selector(setImageUrl:) type:NSString.class],
-      @"contentIndexingMode": [self propertyWithSetterSelector:@selector(setContentIndexingMode:) type:NSString.class],
-      @"title": [self propertyWithSetterSelector:@selector(setTitle:) type:NSString.class]
-      };
+    static dispatch_once_t once = 0;
+    dispatch_once(&once, ^{
+        _universalObjectProperties =
+        @{
+          @"canonicalUrl": [self propertyWithSetterSelector:@selector(setCanonicalUrl:) type:NSString.class],
+          @"contentDescription": [self propertyWithSetterSelector:@selector(setContentDescription:) type:NSString.class],
+          @"contentImageUrl": [self propertyWithSetterSelector:@selector(setImageUrl:) type:NSString.class],
+          @"contentIndexingMode": [self propertyWithSetterSelector:@selector(setContentIndexingMode:) type:NSString.class],
+          @"title": [self propertyWithSetterSelector:@selector(setTitle:) type:NSString.class]
+          };
+    });
 
     return _universalObjectProperties;
 }

--- a/ios/RNBranchProperty.m
+++ b/ios/RNBranchProperty.m
@@ -1,0 +1,115 @@
+//
+//  RNBranchProperty.m
+//  RNBranch
+//
+//  Created by Jimmy Dee on 1/26/17.
+//  Copyright © 2017 Dispatcher. All rights reserved.
+//
+
+#import "RNBranchProperty.h"
+#import "BranchUniversalObject+RNBranch.h"
+
+@interface RNBranchProperty()
+@property (nonatomic) SEL setterSelector;
+@property (nonatomic) Class type;
+
++ (void)setProperties:(NSDictionary<NSString *, RNBranchProperty *> *)properties onObject:(NSObject *)object fromMap:(NSDictionary *)map;
+
++ (NSDictionary<NSString *, RNBranchProperty *> *)linkProperties;
++ (NSDictionary<NSString *, RNBranchProperty *> *)universalObjectProperties;
+
++ (instancetype) propertyWithSetterSelector:(SEL)selector type:(Class)type;
+
+- (instancetype) initWithSetterSelector:(SEL)selector type:(Class)type NS_DESIGNATED_INITIALIZER;
+@end
+
+@implementation RNBranchProperty
+
++ (void)setLinkPropertiesOn:(BranchLinkProperties *)linkProperties fromMap:(NSDictionary *)map
+{
+    [self setProperties:self.linkProperties onObject:linkProperties fromMap:map];
+}
+
++ (void)setUniversalObjectPropertiesOn:(BranchUniversalObject *)universalObject fromMap:(NSDictionary *)map
+{
+    [self setProperties:self.universalObjectProperties onObject:universalObject fromMap:map];
+}
+
++ (NSDictionary<NSString *, RNBranchProperty *> *)linkProperties
+{
+    static NSDictionary<NSString *, RNBranchProperty *> *_linkProperties;
+    if (_linkProperties) return _linkProperties;
+
+    _linkProperties =
+    @{
+      @"alias": [self propertyWithSetterSelector:@selector(setAlias:) type:NSString.class],
+      @"campaign": [self propertyWithSetterSelector:@selector(setCampaign:) type:NSString.class],
+      @"channel": [self propertyWithSetterSelector:@selector(setChannel:) type:NSString.class],
+      // @"duration": [self propertyWithSetterSelector:@selector(setMatchDuration:) type:NSNumber.class], // deprecated
+      @"feature": [self propertyWithSetterSelector:@selector(setFeature:) type:NSString.class],
+      @"stage": [self propertyWithSetterSelector:@selector(setStage:) type:NSString.class],
+      @"tags": [self propertyWithSetterSelector:@selector(setTags:) type:NSArray.class]
+      };
+
+    return _linkProperties;
+}
+
++ (NSDictionary<NSString *,RNBranchProperty *> *)universalObjectProperties
+{
+    static NSDictionary<NSString *, RNBranchProperty *> *_universalObjectProperties;
+    if (!_universalObjectProperties) return _universalObjectProperties;
+
+    _universalObjectProperties =
+    @{
+      @"canonicalUrl": [self propertyWithSetterSelector:@selector(setCanonicalUrl:) type:NSString.class],
+      @"contentDescription": [self propertyWithSetterSelector:@selector(setContentDescription:) type:NSString.class],
+      @"contentImageUrl": [self propertyWithSetterSelector:@selector(setImageUrl:) type:NSString.class],
+      @"contentIndexingMode": [self propertyWithSetterSelector:@selector(setContentIndexingMode:) type:NSString.class],
+      @"title": [self propertyWithSetterSelector:@selector(setTitle:) type:NSString.class]
+      };
+
+    return _universalObjectProperties;
+}
+
++ (instancetype)propertyWithSetterSelector:(SEL)selector type:(Class)type
+{
+    return [[self alloc] initWithSetterSelector:selector type:type];
+}
+
+- (instancetype)initWithSetterSelector:(SEL)selector type:(Class)type
+{
+    self = [super init];
+    if (self) {
+        _setterSelector = selector;
+        _type = type;
+    }
+    return self;
+}
+
++ (void)setProperties:(NSDictionary<NSString *, RNBranchProperty *> *)properties onObject:(NSObject *)object fromMap:(NSDictionary *)map
+{
+    for (NSString *key in map.allKeys) {
+        RNBranchProperty *property = properties[key];
+        if (!property) {
+            NSLog(@"\"%@\" is not a supported link property.", key);
+            continue;
+        }
+
+        id value = map[key];
+        Class type = property.type;
+        if (![value isKindOfClass:type]) {
+            NSLog(@"\"%@\" requires a value of type %@.", key, NSStringFromClass(type));
+            continue;
+        }
+
+        SEL setterSelector = property.setterSelector;
+        if (![object respondsToSelector:setterSelector]) {
+            NSLog(@"\"%@\" is not supported by the installed version of the native Branch SDK for objects of type %@. Please update to the current release using \"pod update\" or \"carthage update\".", key, NSStringFromClass(object.class));
+            continue;
+        }
+
+        [object performSelector:setterSelector withObject:value];
+    }
+}
+
+@end

--- a/ios/RNBranchProperty.m
+++ b/ios/RNBranchProperty.m
@@ -9,6 +9,8 @@
 #import "RNBranchProperty.h"
 #import "BranchUniversalObject+RNBranch.h"
 
+#import "RCTLog.h"
+
 @interface RNBranchProperty()
 @property (nonatomic) SEL setterSelector;
 @property (nonatomic) Class type;
@@ -66,6 +68,7 @@
           @"contentDescription": [self propertyWithSetterSelector:@selector(setContentDescription:) type:NSString.class],
           @"contentImageUrl": [self propertyWithSetterSelector:@selector(setImageUrl:) type:NSString.class],
           @"contentIndexingMode": [self propertyWithSetterSelector:@selector(setContentIndexingMode:) type:NSString.class],
+          @"metadata": [self propertyWithSetterSelector:@selector(setMetadata:) type:NSDictionary.class],
           @"title": [self propertyWithSetterSelector:@selector(setTitle:) type:NSString.class]
           };
     });
@@ -93,20 +96,20 @@
     for (NSString *key in map.allKeys) {
         RNBranchProperty *property = properties[key];
         if (!property) {
-            NSLog(@"\"%@\" is not a supported %@ property.", properties == self.linkProperties ? @"link" : @"universal object", key);
+            RCTLogWarn(@"\"%@\" is not a supported %@ property.", key, properties == self.linkProperties ? @"link" : @"universal object");
             continue;
         }
 
         id value = map[key];
         Class type = property.type;
         if (![value isKindOfClass:type]) {
-            NSLog(@"\"%@\" requires a value of type %@.", key, NSStringFromClass(type));
+            RCTLogWarn(@"\"%@\" requires a value of type %@.", key, NSStringFromClass(type));
             continue;
         }
 
         SEL setterSelector = property.setterSelector;
         if (![object respondsToSelector:setterSelector]) {
-            NSLog(@"\"%@\" is not supported by the installed version of the native Branch SDK for objects of type %@. Please update to the current release using \"pod update\" or \"carthage update\".", key, NSStringFromClass(object.class));
+            RCTLogWarn(@"\"%@\" is not supported by the installed version of the native Branch SDK for objects of type %@. Please update to the current release using \"pod update\" or \"carthage update\".", key, NSStringFromClass(object.class));
             continue;
         }
 


### PR DESCRIPTION
This change is intended to help out in cases like #84. RN users are not necessarily familiar with CocoaPods or Carthage. It's easy to run `pod install`, e.g., get an old version of the SDK and have build problems for reasons that are not obvious (though in that case we can help out in the docs by recommending `pod install --repo-update`). It's also easy to forget to update the native SDK when updating the react-native-branch module. In the long run, I'd like to bundle the Branch SDK in with the native RNBranch code in order to avoid a) the necessity to even install CocoaPods or Carthage in order to use react-native-branch; b) the need to document different installation options; c) any possibility of a version mismatch. This closely resembles the way that Facebook bundles all native code with the NPM module to the point of discontinuing the React pod in CocoaPods, so that the only way to get to it is to use the version in the NPM module, which is always the right version. There's otherwise no way to require a specific native SDK version with a specific NPM package version. However, that is likely to be a breaking change, have other consequences and require a lot of testing.

The changes in this branch for 0.9.1 (and later 1.0.1) allow any known property of BranchLinkProperties or BranchUniversalObject to be passed in safely. A warning will be generated in the NSLog at runtime. The user who reported #84 had version 0.12.4 of the Branch iOS SDK installed. With these changes, they would have seen:

```
"alias" is not supported by the installed version of the native Branch SDK for objects of type BranchLinkProperties. Please update to the current release using "pod update" or "carthage update".
```

This ought to help others avoid the same kinds of issues.

The same approach is used for link properties and universal object properties. Note that many properties not supported by 0.9 or 1.0 are currently listed in the README for this repo. This change supports all documented fields in 0.9.1.
