### PR TITLE
[android] Remove onStop remains from the docs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -78,7 +78,7 @@ After [installing](./installation.md) Branch, you will need to set up your andro
             return "base";
         }
 
-        // Override onStart, onStop, onNewIntent:
+        // Override onStart, onNewIntent:
         @Override
         protected void onStart() {
             super.onStart();

--- a/testbed/testbed_carthage/android/app/src/main/java/com/testbed_carthage/MainActivity.java
+++ b/testbed/testbed_carthage/android/app/src/main/java/com/testbed_carthage/MainActivity.java
@@ -15,7 +15,7 @@ public class MainActivity extends ReactActivity {
         return "testbed_carthage";
     }
 
-    // Override onStart, onStop, onNewIntent:
+    // Override onStart, onNewIntent:
     @Override
     protected void onStart() {
         super.onStart();


### PR DESCRIPTION
Follow up on commit 779a5f3c34a3c2192b2cbe7c00b93973b9e6da87. There were comments referencing the no longer used `onStop` function.