### PR TITLE
Non-Branch URLs

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -49,12 +49,13 @@ RCT_EXPORT_MODULE();
 }
 
 + (BOOL)handleDeepLink:(NSURL *)url {
-    sourceUrl = url ? url.absoluteString : [NSNull null];
+    sourceUrl = url.absoluteString ?: [NSNull null];
     BOOL handled = [branchInstance handleDeepLink:url];
     return handled;
 }
 
 + (BOOL)continueUserActivity:(NSUserActivity *)userActivity {
+    sourceUrl = userActivity.webpageURL.absoluteString ?: [NSNull null];
     return [branchInstance continueUserActivity:userActivity];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-branch",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Branch Metrics React Native SDK",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
Allow users of react-native-branch to receive `branch.subscribe` callbacks for non-Branch Universal and App Links. See #102.

For some reason, the callbacks to initSession in each native layer filter out params that do not contain the `~id` parameter. The JS callback is invoked, but params is null. Since only Branch links have that parameter, non-Branch opens return null for params, and the `+non_branch_link` parameter is not available.

The Android native layer passes the original URL in the `uri` property of the object passed to the `branch.subscribe` callback in every case. The iOS native layer was only doing this for custom URIs, not Universal Links. That is the only change in this PR: Pass the `uri` parameter for iOS Universal Links as well, for consistency. Now that field will always be populated with the original URL/URI that opened the app, which should be the same as the `~referring_link` parameter for Branch links. It will be necessary to distinguish links morphologically using the domain, scheme and so on.

It may be worth revisiting the filter on the `~id` parameter.

To enable this functionality for non-Branch links, it's only necessary to add the non-Branch domains to `branch_universal_link_domains` in the Info.plist of the iOS target. On Android, the intent-filters for Branch and non-Branch domains and URI schemes should reside in the same Activity.