### PR TITLE
Add manually imported Branch.framework to the Framework Search Paths

### DIFF
--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -286,6 +286,11 @@
 		B3A3CC401C5B0A070016AC52 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(CARTHAGE_ROOT)/Build/iOS",
+					"$(PODS_CONFIGURATION_BUILD_DIR)/Branch",
+					"$(SRCROOT)/../../../ios",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "react-native-branch";
 				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PRODUCT_NAME)";
@@ -295,6 +300,11 @@
 		B3A3CC411C5B0A070016AC52 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(CARTHAGE_ROOT)/Build/iOS",
+					"$(PODS_CONFIGURATION_BUILD_DIR)/Branch",
+					"$(SRCROOT)/../../../ios",
+				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "react-native-branch";
 				PUBLIC_HEADERS_FOLDER_PATH = "/usr/local/include/$(PRODUCT_NAME)";


### PR DESCRIPTION
We don't use Cocoapods or Carthage in our project, so we manually imported the `Branch.framework` and had to fix the `Framework Search Paths` in `RNBranch.xcodeproj`.

Every time we update the package version the it resets this setting.

Can we have it in the default configuration?

Thanks :)