### PR TITLE
Add a recursive framework search path for manual installation

### DIFF
--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(CARTHAGE_ROOT)/Build/iOS",
 					"$(PODS_CONFIGURATION_BUILD_DIR)/Branch",
+					"$(SRCROOT)/../../../ios/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -262,6 +263,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(CARTHAGE_ROOT)/Build/iOS",
 					"$(PODS_CONFIGURATION_BUILD_DIR)/Branch",
+					"$(SRCROOT)/../../../ios/**",
 				);
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_NO_COMMON_BLOCKS = YES;


### PR DESCRIPTION
See #106.

This adds a recursive framework search path at the project level for a manually-installed Branch SDK. The recursive path is `$(SRCROOT)/../../../ios/**`. This will search the RN project's ios subdirectory and all its subdirectories recursively.