### PR TITLE
Wrap native BUO

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -32,7 +32,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     public static final String REACT_MODULE_NAME = "RNBranch";
     private static final String NATIVE_INIT_SESSION_FINISHED_EVENT = "onInitSessionFinished";
     private static final String RN_INIT_SESSION_EVENT = "RNBranch.initSessionSuccess";
-    private static final String IDENT_FIELD_NAME = "+ident";
+    private static final String IDENT_FIELD_NAME = "ident";
 
     private static JSONObject initSessionResult = null;
     private BroadcastReceiver mInitSessionEventReceiver = null;

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -28,83 +28,83 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 public class RNBranchModule extends ReactContextBaseJavaModule {
-  public static final String REACT_CLASS = "RNBranch";
-  public static final String REACT_MODULE_NAME = "RNBranch";
-  private static final String NATIVE_INIT_SESSION_FINISHED_EVENT = "onInitSessionFinished";
-  private static final String RN_INIT_SESSION_EVENT = "RNBranch.initSessionSuccess";
+    public static final String REACT_CLASS = "RNBranch";
+    public static final String REACT_MODULE_NAME = "RNBranch";
+    private static final String NATIVE_INIT_SESSION_FINISHED_EVENT = "onInitSessionFinished";
+    private static final String RN_INIT_SESSION_EVENT = "RNBranch.initSessionSuccess";
 
-  private static JSONObject initSessionResult = null;
-  private BroadcastReceiver mInitSessionEventReceiver = null;
+    private static JSONObject initSessionResult = null;
+    private BroadcastReceiver mInitSessionEventReceiver = null;
 
-  private static Activity mActivity = null;
-  private static Branch mBranch = null;
+    private static Activity mActivity = null;
+    private static Branch mBranch = null;
 
-  private HashMap<String, BranchUniversalObject> mUniversalObjectMap = new HashMap<>();
+    private HashMap<String, BranchUniversalObject> mUniversalObjectMap = new HashMap<>();
 
-  public static void initSession(final Uri uri, Activity reactActivity) {
-    mBranch = Branch.getInstance(reactActivity.getApplicationContext());
-    mActivity = reactActivity;
-    mBranch.initSession(new Branch.BranchReferralInitListener(){
+    public static void initSession(final Uri uri, Activity reactActivity) {
+        mBranch = Branch.getInstance(reactActivity.getApplicationContext());
+        mActivity = reactActivity;
+        mBranch.initSession(new Branch.BranchReferralInitListener(){
 
-      private Activity mmActivity = null;
+            private Activity mmActivity = null;
 
-      @Override
-      public void onInitFinished(JSONObject referringParams, BranchError error) {
+            @Override
+            public void onInitFinished(JSONObject referringParams, BranchError error) {
 
-        Log.d(REACT_CLASS, "onInitFinished");
-        JSONObject result = new JSONObject();
-        try{
-          result.put("params", referringParams != null && referringParams.has("~id") ? referringParams : JSONObject.NULL);
-          result.put("error", error != null ? error.getMessage() : JSONObject.NULL);
-          result.put("uri", uri != null ? uri.toString() : JSONObject.NULL);
-        } catch(JSONException ex) {
-          try {
-            result.put("error", "Failed to convert result to JSONObject: " + ex.getMessage());
-          } catch(JSONException k) {}
-        }
-        initSessionResult = result;
-        LocalBroadcastManager.getInstance(mmActivity).sendBroadcast(new Intent(NATIVE_INIT_SESSION_FINISHED_EVENT));
-      }
+                Log.d(REACT_CLASS, "onInitFinished");
+                JSONObject result = new JSONObject();
+                try{
+                    result.put("params", referringParams != null && referringParams.has("~id") ? referringParams : JSONObject.NULL);
+                    result.put("error", error != null ? error.getMessage() : JSONObject.NULL);
+                    result.put("uri", uri != null ? uri.toString() : JSONObject.NULL);
+                } catch(JSONException ex) {
+                    try {
+                        result.put("error", "Failed to convert result to JSONObject: " + ex.getMessage());
+                    } catch(JSONException k) {}
+                }
+                initSessionResult = result;
+                LocalBroadcastManager.getInstance(mmActivity).sendBroadcast(new Intent(NATIVE_INIT_SESSION_FINISHED_EVENT));
+            }
 
-      private Branch.BranchReferralInitListener init(Activity activity) {
-        mmActivity = activity;
-        return this;
-      }
-    }.init(reactActivity), uri, reactActivity);
-  }
+            private Branch.BranchReferralInitListener init(Activity activity) {
+                mmActivity = activity;
+                return this;
+            }
+        }.init(reactActivity), uri, reactActivity);
+    }
 
-  public RNBranchModule(ReactApplicationContext reactContext) {
-    super(reactContext);
-    forwardInitSessionFinishedEventToReactNative(reactContext);
-  }
+    public RNBranchModule(ReactApplicationContext reactContext) {
+        super(reactContext);
+        forwardInitSessionFinishedEventToReactNative(reactContext);
+    }
 
-  private void forwardInitSessionFinishedEventToReactNative(ReactApplicationContext reactContext) {
-    mInitSessionEventReceiver = new BroadcastReceiver() {
-      RNBranchModule mBranchModule;
+    private void forwardInitSessionFinishedEventToReactNative(ReactApplicationContext reactContext) {
+        mInitSessionEventReceiver = new BroadcastReceiver() {
+            RNBranchModule mBranchModule;
 
-      @Override
-      public void onReceive(Context context, Intent intent) {
-        mBranchModule.sendRNEvent(RN_INIT_SESSION_EVENT, convertJsonToMap(initSessionResult));
-      }
+            @Override
+            public void onReceive(Context context, Intent intent) {
+                mBranchModule.sendRNEvent(RN_INIT_SESSION_EVENT, convertJsonToMap(initSessionResult));
+            }
 
-      private BroadcastReceiver init(RNBranchModule branchModule) {
-        mBranchModule = branchModule;
-        return this;
-      }
-    }.init(this);
+            private BroadcastReceiver init(RNBranchModule branchModule) {
+                mBranchModule = branchModule;
+                return this;
+            }
+        }.init(this);
 
-    LocalBroadcastManager.getInstance(reactContext).registerReceiver(mInitSessionEventReceiver, new IntentFilter(NATIVE_INIT_SESSION_FINISHED_EVENT));
-  }
+        LocalBroadcastManager.getInstance(reactContext).registerReceiver(mInitSessionEventReceiver, new IntentFilter(NATIVE_INIT_SESSION_FINISHED_EVENT));
+    }
 
-  @Override
-  public void onCatalystInstanceDestroy() {
-    LocalBroadcastManager.getInstance(getReactApplicationContext()).unregisterReceiver(mInitSessionEventReceiver);
-  }
+    @Override
+    public void onCatalystInstanceDestroy() {
+        LocalBroadcastManager.getInstance(getReactApplicationContext()).unregisterReceiver(mInitSessionEventReceiver);
+    }
 
-  @Override
-  public String getName() {
-    return REACT_MODULE_NAME;
-  }
+    @Override
+    public String getName() {
+        return REACT_MODULE_NAME;
+    }
 
     @ReactMethod
     public void createUniversalObject(ReadableMap universalObjectMap, Promise promise) {
@@ -122,545 +122,545 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         mUniversalObjectMap.remove(ident);
     }
 
-  @ReactMethod
-  public void redeemInitSessionResult(Promise promise) {
-    promise.resolve(convertJsonToMap(initSessionResult));
-    initSessionResult = null;
-  }
+    @ReactMethod
+    public void redeemInitSessionResult(Promise promise) {
+        promise.resolve(convertJsonToMap(initSessionResult));
+        initSessionResult = null;
+    }
 
-  @ReactMethod
-  public void setDebug() {
-    Branch branch = Branch.getInstance();
-    branch.setDebug();
-  }
+    @ReactMethod
+    public void setDebug() {
+        Branch branch = Branch.getInstance();
+        branch.setDebug();
+    }
 
-  @ReactMethod
-  public void getLatestReferringParams(Promise promise) {
-    Branch branch = Branch.getInstance();
-    promise.resolve(convertJsonToMap(branch.getLatestReferringParams()));
-  }
+    @ReactMethod
+    public void getLatestReferringParams(Promise promise) {
+        Branch branch = Branch.getInstance();
+        promise.resolve(convertJsonToMap(branch.getLatestReferringParams()));
+    }
 
-  @ReactMethod
-  public void getFirstReferringParams(Promise promise) {
-    Branch branch = Branch.getInstance();
-    promise.resolve(convertJsonToMap(branch.getFirstReferringParams()));
-  }
+    @ReactMethod
+    public void getFirstReferringParams(Promise promise) {
+        Branch branch = Branch.getInstance();
+        promise.resolve(convertJsonToMap(branch.getFirstReferringParams()));
+    }
 
-  @ReactMethod
-  public void setIdentity(String identity) {
-    Branch branch = Branch.getInstance();
-    branch.setIdentity(identity);
-  }
+    @ReactMethod
+    public void setIdentity(String identity) {
+        Branch branch = Branch.getInstance();
+        branch.setIdentity(identity);
+    }
 
-  @ReactMethod
-  public void logout() {
-    Branch branch = Branch.getInstance();
-    branch.logout();
-  }
+    @ReactMethod
+    public void logout() {
+        Branch branch = Branch.getInstance();
+        branch.logout();
+    }
 
-  @ReactMethod
-  public void userCompletedAction(String event, ReadableMap appState) throws JSONException {
-    Branch branch = Branch.getInstance();
-    branch.userCompletedAction(event, convertMapToJson(appState));
-  }
+    @ReactMethod
+    public void userCompletedAction(String event, ReadableMap appState) throws JSONException {
+        Branch branch = Branch.getInstance();
+        branch.userCompletedAction(event, convertMapToJson(appState));
+    }
 
-  @ReactMethod
-  public void showShareSheet(String ident, ReadableMap shareOptionsMap, ReadableMap linkPropertiesMap, ReadableMap controlParamsMap, Promise promise) {
-    Context context = getReactApplicationContext();
+    @ReactMethod
+    public void showShareSheet(String ident, ReadableMap shareOptionsMap, ReadableMap linkPropertiesMap, ReadableMap controlParamsMap, Promise promise) {
+        Context context = getReactApplicationContext();
 
-    Handler mainHandler = new Handler(context.getMainLooper());
+        Handler mainHandler = new Handler(context.getMainLooper());
 
-    Runnable myRunnable = new Runnable() {
-      Promise mPm;
-      Context mContext;
-      ReadableMap shareOptionsMap, linkPropertiesMap, controlParamsMap;
-        String ident;
+        Runnable myRunnable = new Runnable() {
+            Promise mPm;
+            Context mContext;
+            ReadableMap shareOptionsMap, linkPropertiesMap, controlParamsMap;
+            String ident;
 
-      private Runnable init(ReadableMap _shareOptionsMap, String _ident, ReadableMap _linkPropertiesMap, ReadableMap _controlParamsMap, Promise promise, Context context) {
-        mPm = promise;
-        mContext = context;
-        shareOptionsMap = _shareOptionsMap;
-        ident = _ident;
-        linkPropertiesMap = _linkPropertiesMap;
-        controlParamsMap = _controlParamsMap;
-        return this;
-      }
+            private Runnable init(ReadableMap _shareOptionsMap, String _ident, ReadableMap _linkPropertiesMap, ReadableMap _controlParamsMap, Promise promise, Context context) {
+                mPm = promise;
+                mContext = context;
+                shareOptionsMap = _shareOptionsMap;
+                ident = _ident;
+                linkPropertiesMap = _linkPropertiesMap;
+                controlParamsMap = _controlParamsMap;
+                return this;
+            }
 
-      @Override
-      public void run() {
-        String messageHeader = shareOptionsMap.hasKey("messageHeader") ? shareOptionsMap.getString("messageHeader") : "";
-        String messageBody = shareOptionsMap.hasKey("messageBody") ? shareOptionsMap.getString("messageBody") : "";
-        ShareSheetStyle shareSheetStyle = new ShareSheetStyle(mContext, messageHeader, messageBody)
-          .setCopyUrlStyle(mContext.getResources().getDrawable(android.R.drawable.ic_menu_send), "Copy", "Added to clipboard")
-          .setMoreOptionStyle(mContext.getResources().getDrawable(android.R.drawable.ic_menu_search), "Show more")
-          .addPreferredSharingOption(SharingHelper.SHARE_WITH.EMAIL)
-          .addPreferredSharingOption(SharingHelper.SHARE_WITH.TWITTER)
-          .addPreferredSharingOption(SharingHelper.SHARE_WITH.MESSAGE)
-          .addPreferredSharingOption(SharingHelper.SHARE_WITH.FACEBOOK);
+            @Override
+            public void run() {
+                String messageHeader = shareOptionsMap.hasKey("messageHeader") ? shareOptionsMap.getString("messageHeader") : "";
+                String messageBody = shareOptionsMap.hasKey("messageBody") ? shareOptionsMap.getString("messageBody") : "";
+                ShareSheetStyle shareSheetStyle = new ShareSheetStyle(mContext, messageHeader, messageBody)
+                        .setCopyUrlStyle(mContext.getResources().getDrawable(android.R.drawable.ic_menu_send), "Copy", "Added to clipboard")
+                        .setMoreOptionStyle(mContext.getResources().getDrawable(android.R.drawable.ic_menu_search), "Show more")
+                        .addPreferredSharingOption(SharingHelper.SHARE_WITH.EMAIL)
+                        .addPreferredSharingOption(SharingHelper.SHARE_WITH.TWITTER)
+                        .addPreferredSharingOption(SharingHelper.SHARE_WITH.MESSAGE)
+                        .addPreferredSharingOption(SharingHelper.SHARE_WITH.FACEBOOK);
+
+                BranchUniversalObject branchUniversalObject = findUniversalObject(ident);
+
+                LinkProperties linkProperties = createLinkProperties(linkPropertiesMap, controlParamsMap);
+
+                branchUniversalObject.showShareSheet(
+                        getCurrentActivity(),
+                        linkProperties,
+                        shareSheetStyle,
+                        new Branch.BranchLinkShareListener() {
+                            private Promise mPromise = null;
+
+                            @Override
+                            public void onShareLinkDialogLaunched() {
+                            }
+
+                            @Override
+                            public void onShareLinkDialogDismissed() {
+                                if(mPromise == null) {
+                                    return;
+                                }
+
+                                WritableMap map = new WritableNativeMap();
+                                map.putString("channel", null);
+                                map.putBoolean("completed", false);
+                                map.putString("error", null);
+                                mPromise.resolve(map);
+                                mPromise = null;
+                            }
+
+                            @Override
+                            public void onLinkShareResponse(String sharedLink, String sharedChannel, BranchError error) {
+                                if(mPromise == null) {
+                                    return;
+                                }
+
+                                WritableMap map = new WritableNativeMap();
+                                map.putString("channel", sharedChannel);
+                                map.putBoolean("completed", true);
+                                map.putString("error", (error != null ? error.getMessage() : null));
+                                mPromise.resolve(map);
+                                mPromise = null;
+                            }
+                            @Override
+                            public void onChannelSelected(String channelName) {
+                            }
+
+                            private Branch.BranchLinkShareListener init(Promise promise) {
+                                mPromise = promise;
+                                return this;
+                            }
+                        }.init(mPm));
+            }
+        }.init(shareOptionsMap, ident, linkPropertiesMap, controlParamsMap, promise, context);
+
+        mainHandler.post(myRunnable);
+    }
+
+    @ReactMethod
+    public void registerView(String ident, Promise promise) {
+        BranchUniversalObject branchUniversalObject = findUniversalObject(ident);
+        branchUniversalObject.registerView();
+        promise.resolve(null);
+    }
+
+    @ReactMethod
+    public void generateShortUrl(String ident, ReadableMap linkPropertiesMap, ReadableMap controlParamsMap, final Promise promise) {
+        LinkProperties linkProperties = createLinkProperties(linkPropertiesMap, controlParamsMap);
 
         BranchUniversalObject branchUniversalObject = findUniversalObject(ident);
 
-        LinkProperties linkProperties = createLinkProperties(linkPropertiesMap, controlParamsMap);
-
-        branchUniversalObject.showShareSheet(
-        getCurrentActivity(),
-        linkProperties,
-        shareSheetStyle,
-        new Branch.BranchLinkShareListener() {
-          private Promise mPromise = null;
-
-          @Override
-          public void onShareLinkDialogLaunched() {
-          }
-
-          @Override
-          public void onShareLinkDialogDismissed() {
-            if(mPromise == null) {
-              return;
+        branchUniversalObject.generateShortUrl(mActivity, linkProperties, new BranchLinkCreateListener() {
+            @Override
+            public void onLinkCreate(String url, BranchError error) {
+                Log.d(REACT_CLASS, "onLinkCreate " + url);
+                WritableMap map = new WritableNativeMap();
+                map.putString("url", url);
+                if (error != null) {
+                    map.putString("error", error.toString());
+                }
+                promise.resolve(map);
             }
+        });
+    }
 
-            WritableMap map = new WritableNativeMap();
-            map.putString("channel", null);
-            map.putBoolean("completed", false);
-            map.putString("error", null);
-            mPromise.resolve(map);
-            mPromise = null;
-          }
+    public static LinkProperties createLinkProperties(ReadableMap linkPropertiesMap, @Nullable ReadableMap controlParams){
+        LinkProperties linkProperties = new LinkProperties();
+        if (linkPropertiesMap.hasKey("alias")) linkProperties.setFeature(linkPropertiesMap.getString("alias"));
+        if (linkPropertiesMap.hasKey("campaign")) linkProperties.setFeature(linkPropertiesMap.getString("campaign"));
+        if (linkPropertiesMap.hasKey("channel")) linkProperties.setChannel(linkPropertiesMap.getString("channel"));
+        if (linkPropertiesMap.hasKey("feature")) linkProperties.setFeature(linkPropertiesMap.getString("feature"));
+        if (linkPropertiesMap.hasKey("stage")) linkProperties.setFeature(linkPropertiesMap.getString("stage"));
 
-          @Override
-          public void onLinkShareResponse(String sharedLink, String sharedChannel, BranchError error) {
-            if(mPromise == null) {
-              return;
+        if (linkPropertiesMap.hasKey("tags")) {
+            ReadableArray tags = linkPropertiesMap.getArray("tags");
+            for (int i=0; i<tags.size(); ++i) {
+                String tag = tags.getString(i);
+                linkProperties.addTag(tag);
             }
-
-            WritableMap map = new WritableNativeMap();
-            map.putString("channel", sharedChannel);
-            map.putBoolean("completed", true);
-            map.putString("error", (error != null ? error.getMessage() : null));
-            mPromise.resolve(map);
-            mPromise = null;
-          }
-          @Override
-          public void onChannelSelected(String channelName) {
-          }
-
-          private Branch.BranchLinkShareListener init(Promise promise) {
-            mPromise = promise;
-            return this;
-          }
-        }.init(mPm));
-      }
-    }.init(shareOptionsMap, ident, linkPropertiesMap, controlParamsMap, promise, context);
-
-    mainHandler.post(myRunnable);
-  }
-
-  @ReactMethod
-  public void registerView(String ident, Promise promise) {
-    BranchUniversalObject branchUniversalObject = findUniversalObject(ident);
-    branchUniversalObject.registerView();
-    promise.resolve(null);
-  }
-
-  @ReactMethod
-  public void generateShortUrl(String ident, ReadableMap linkPropertiesMap, ReadableMap controlParamsMap, final Promise promise) {
-    LinkProperties linkProperties = createLinkProperties(linkPropertiesMap, controlParamsMap);
-
-    BranchUniversalObject branchUniversalObject = findUniversalObject(ident);
-
-    branchUniversalObject.generateShortUrl(mActivity, linkProperties, new BranchLinkCreateListener() {
-      @Override
-      public void onLinkCreate(String url, BranchError error) {
-        Log.d(REACT_CLASS, "onLinkCreate " + url);
-        WritableMap map = new WritableNativeMap();
-        map.putString("url", url);
-        if (error != null) {
-          map.putString("error", error.toString());
         }
-        promise.resolve(map);
-      }
-    });
-  }
 
-  public static LinkProperties createLinkProperties(ReadableMap linkPropertiesMap, @Nullable ReadableMap controlParams){
-    LinkProperties linkProperties = new LinkProperties();
-    if (linkPropertiesMap.hasKey("alias")) linkProperties.setFeature(linkPropertiesMap.getString("alias"));
-    if (linkPropertiesMap.hasKey("campaign")) linkProperties.setFeature(linkPropertiesMap.getString("campaign"));
-    if (linkPropertiesMap.hasKey("channel")) linkProperties.setChannel(linkPropertiesMap.getString("channel"));
-    if (linkPropertiesMap.hasKey("feature")) linkProperties.setFeature(linkPropertiesMap.getString("feature"));
-    if (linkPropertiesMap.hasKey("stage")) linkProperties.setFeature(linkPropertiesMap.getString("stage"));
+        if (controlParams != null) {
+            ReadableMapKeySetIterator iterator = controlParams.keySetIterator();
+            while (iterator.hasNextKey()) {
+                String key = iterator.nextKey();
+                Object value = getReadableMapObjectForKey(controlParams, key);
+                linkProperties.addControlParameter(key, value.toString());
+            }
+        }
 
-    if (linkPropertiesMap.hasKey("tags")) {
-      ReadableArray tags = linkPropertiesMap.getArray("tags");
-      for (int i=0; i<tags.size(); ++i) {
-        String tag = tags.getString(i);
-        linkProperties.addTag(tag);
-      }
+        return linkProperties;
     }
-
-    if (controlParams != null) {
-      ReadableMapKeySetIterator iterator = controlParams.keySetIterator();
-      while (iterator.hasNextKey()) {
-        String key = iterator.nextKey();
-        Object value = getReadableMapObjectForKey(controlParams, key);
-        linkProperties.addControlParameter(key, value.toString());
-      }
-    }
-
-    return linkProperties;
-  }
 
     public BranchUniversalObject findUniversalObject(String ident) {
         return mUniversalObjectMap.get(ident);
     }
 
-  public BranchUniversalObject createBranchUniversalObject(ReadableMap branchUniversalObjectMap) {
-    BranchUniversalObject branchUniversalObject = new BranchUniversalObject()
-      .setCanonicalIdentifier(branchUniversalObjectMap.getString("canonicalIdentifier"));
+    public BranchUniversalObject createBranchUniversalObject(ReadableMap branchUniversalObjectMap) {
+        BranchUniversalObject branchUniversalObject = new BranchUniversalObject()
+                .setCanonicalIdentifier(branchUniversalObjectMap.getString("canonicalIdentifier"));
 
-    if (branchUniversalObjectMap.hasKey("title")) branchUniversalObject.setTitle(branchUniversalObjectMap.getString("title"));
-    if (branchUniversalObjectMap.hasKey("canonicalUrl")) branchUniversalObject.setCanonicalUrl(branchUniversalObjectMap.getString("canonicalUrl"));
-    if (branchUniversalObjectMap.hasKey("contentDescription")) branchUniversalObject.setContentDescription(branchUniversalObjectMap.getString("contentDescription"));
-    if (branchUniversalObjectMap.hasKey("contentImageUrl")) branchUniversalObject.setContentImageUrl(branchUniversalObjectMap.getString("contentImageUrl"));
-    if (branchUniversalObjectMap.hasKey("contentIndexingMode")) {
-      switch (branchUniversalObjectMap.getType("contentIndexingMode")) {
-        case String:
-          String mode = branchUniversalObjectMap.getString("contentIndexingMode");
+        if (branchUniversalObjectMap.hasKey("title")) branchUniversalObject.setTitle(branchUniversalObjectMap.getString("title"));
+        if (branchUniversalObjectMap.hasKey("canonicalUrl")) branchUniversalObject.setCanonicalUrl(branchUniversalObjectMap.getString("canonicalUrl"));
+        if (branchUniversalObjectMap.hasKey("contentDescription")) branchUniversalObject.setContentDescription(branchUniversalObjectMap.getString("contentDescription"));
+        if (branchUniversalObjectMap.hasKey("contentImageUrl")) branchUniversalObject.setContentImageUrl(branchUniversalObjectMap.getString("contentImageUrl"));
+        if (branchUniversalObjectMap.hasKey("contentIndexingMode")) {
+            switch (branchUniversalObjectMap.getType("contentIndexingMode")) {
+                case String:
+                    String mode = branchUniversalObjectMap.getString("contentIndexingMode");
 
-          if (mode.equals("private"))
-            branchUniversalObject.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PRIVATE);
-          else if (mode.equals("public"))
-            branchUniversalObject.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC);
-          else
-            Log.w(REACT_CLASS, "Unsupported value for contentIndexingMode: " + mode +
-                    ". Supported values are \"public\" and \"private\"");
-          break;
-        default:
-          Log.w(REACT_CLASS, "contentIndexingMode must be a String");
-          break;
-      }
-    }
-
-    if (branchUniversalObjectMap.hasKey("currency") && branchUniversalObjectMap.hasKey("price")) {
-      String currencyString = branchUniversalObjectMap.getString("currency");
-      CurrencyType currency = CurrencyType.valueOf(currencyString);
-      branchUniversalObject.setPrice(branchUniversalObjectMap.getDouble("price"), currency);
-    }
-
-    if (branchUniversalObjectMap.hasKey("expirationDate")) {
-      String expirationString = branchUniversalObjectMap.getString("expirationDate");
-      SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-      format.setTimeZone(TimeZone.getTimeZone("UTC"));
-      try {
-        Date date = format.parse(expirationString);
-        Log.d(REACT_CLASS, "Expiration date is " + date.toString());
-        branchUniversalObject.setContentExpiration(date);
-      }
-      catch (ParseException e) {
-        Log.w(REACT_CLASS, "Invalid expiration date format. Valid format is YYYY-mm-ddTHH:MM:SS, e.g. 2017-02-01T00:00:00. All times UTC.");
-      }
-    }
-
-    if (branchUniversalObjectMap.hasKey("keywords")) {
-      ReadableArray keywords = branchUniversalObjectMap.getArray("keywords");
-      for (int i=0; i<keywords.size(); ++i) {
-        branchUniversalObject.addKeyWord(keywords.getString(i));
-      }
-    }
-
-    if(branchUniversalObjectMap.hasKey("metadata")) {
-      ReadableMap metadataMap = branchUniversalObjectMap.getMap("metadata");
-      ReadableMapKeySetIterator iterator = metadataMap.keySetIterator();
-      while (iterator.hasNextKey()) {
-        String metadataKey = iterator.nextKey();
-        Object metadataObject = getReadableMapObjectForKey(metadataMap, metadataKey);
-        branchUniversalObject.addContentMetadata(metadataKey, metadataObject.toString());
-      }
-    }
-
-    if (branchUniversalObjectMap.hasKey("type")) branchUniversalObject.setContentType(branchUniversalObjectMap.getString("type"));
-
-    return branchUniversalObject;
-  }
-
-  @ReactMethod
-  public void redeemRewards(int value, String bucket, Promise promise)
-  {
-    if (bucket == null) {
-      Branch.getInstance().redeemRewards(value, new RedeemRewardsListener(promise));
-    } else {
-      Branch.getInstance().redeemRewards(bucket, value, new RedeemRewardsListener(promise));
-    }
-  }
-
-  @ReactMethod
-  public void loadRewards(Promise promise)
-  {
-    Branch.getInstance().loadRewards(new LoadRewardsListener(promise));
-  }
-
-  @ReactMethod
-  public void getCreditHistory(Promise promise)
-  {
-    Branch.getInstance().getCreditHistory(new CreditHistoryListener(promise));
-  }
-
-  protected class CreditHistoryListener implements Branch.BranchListResponseListener
-  {
-    private Promise _promise;
-
-    // Constructor that takes in a required callbackContext object
-    public CreditHistoryListener(Promise promise) {
-      this._promise = promise;
-    }
-
-    // Listener that implements BranchListResponseListener for getCreditHistory()
-    @Override
-    public void onReceivingResponse(JSONArray list, BranchError error) {
-      ArrayList<String> errors = new ArrayList<String>();
-      if (error == null) {
-        try {
-          ReadableArray result = convertJsonToArray(list);
-          this._promise.resolve(result);
-        } catch (JSONException err) {
-          this._promise.reject(err.getMessage());
-        }
-      } else {
-        String errorMessage = error.getMessage();
-        Log.d(REACT_CLASS, errorMessage);
-        this._promise.reject(errorMessage);
-      }
-    }
-  }
-
-  protected class RedeemRewardsListener implements Branch.BranchReferralStateChangedListener
-  {
-    private Promise _promise;
-
-    public RedeemRewardsListener(Promise promise) {
-      this._promise = promise;
-    }
-
-    @Override
-    public void onStateChanged(boolean changed, BranchError error) {
-      if (error == null) {
-        WritableMap map = new WritableNativeMap();
-        map.putBoolean("changed", changed);
-        this._promise.resolve(map);
-      } else {
-        String errorMessage = error.getMessage();
-        Log.d(REACT_CLASS, errorMessage);
-        this._promise.reject(errorMessage);
-      }
-    }
-  }
-
-  protected class LoadRewardsListener implements Branch.BranchReferralStateChangedListener
-  {
-    private Promise _promise;
-
-    public LoadRewardsListener(Promise promise) {
-      this._promise = promise;
-    }
-
-    @Override
-    public void onStateChanged(boolean changed, BranchError error) {
-      if (error == null) {
-        int credits = Branch.getInstance().getCredits();
-        WritableMap map = new WritableNativeMap();
-        map.putInt("credits", credits);
-        this._promise.resolve(map);
-      } else {
-        String errorMessage = error.getMessage();
-        Log.d(REACT_CLASS, errorMessage);
-        this._promise.reject(errorMessage);
-      }
-    }
-  }
-
-  public void sendRNEvent(String eventName, @Nullable WritableMap params) {
-    // This should avoid the crash in getJSModule() at startup
-    // See also: https://github.com/walmartreact/react-native-orientation-listener/issues/8
-
-    ReactApplicationContext context = getReactApplicationContext();
-    Handler mainHandler = new Handler(context.getMainLooper());
-
-    Runnable poller = new Runnable() {
-
-      private Runnable init(ReactApplicationContext _context, Handler _mainHandler, String _eventName, WritableMap _params) {
-        mMainHandler = _mainHandler;
-        mEventName = _eventName;
-        mContext = _context;
-        mParams = _params;
-        return this;
-      }
-
-      final int pollDelayInMs = 100;
-      final int maxTries = 300;
-
-      int tries = 1;
-      String mEventName;
-      WritableMap mParams;
-      Handler mMainHandler;
-      ReactApplicationContext mContext;
-
-      @Override
-      public void run() {
-        try {
-          Log.d(REACT_CLASS, "Catalyst instance poller try " + Integer.toString(tries));
-          if (mContext.hasActiveCatalystInstance()) {
-            Log.d(REACT_CLASS, "Catalyst instance active");
-            mContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-            .emit(mEventName, mParams);
-          } else {
-            tries++;
-            if (tries <= maxTries) {
-              mMainHandler.postDelayed(this, pollDelayInMs);
-            } else {
-              Log.e(REACT_CLASS, "Could not get Catalyst instance");
+                    if (mode.equals("private"))
+                        branchUniversalObject.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PRIVATE);
+                    else if (mode.equals("public"))
+                        branchUniversalObject.setContentIndexingMode(BranchUniversalObject.CONTENT_INDEX_MODE.PUBLIC);
+                    else
+                        Log.w(REACT_CLASS, "Unsupported value for contentIndexingMode: " + mode +
+                                ". Supported values are \"public\" and \"private\"");
+                    break;
+                default:
+                    Log.w(REACT_CLASS, "contentIndexingMode must be a String");
+                    break;
             }
-          }
         }
-        catch (Exception e) {
-          e.printStackTrace();
+
+        if (branchUniversalObjectMap.hasKey("currency") && branchUniversalObjectMap.hasKey("price")) {
+            String currencyString = branchUniversalObjectMap.getString("currency");
+            CurrencyType currency = CurrencyType.valueOf(currencyString);
+            branchUniversalObject.setPrice(branchUniversalObjectMap.getDouble("price"), currency);
         }
-      }
-    }.init(context, mainHandler, eventName, params);
 
-    Log.d(REACT_CLASS, "sendRNEvent");
+        if (branchUniversalObjectMap.hasKey("expirationDate")) {
+            String expirationString = branchUniversalObjectMap.getString("expirationDate");
+            SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+            format.setTimeZone(TimeZone.getTimeZone("UTC"));
+            try {
+                Date date = format.parse(expirationString);
+                Log.d(REACT_CLASS, "Expiration date is " + date.toString());
+                branchUniversalObject.setContentExpiration(date);
+            }
+            catch (ParseException e) {
+                Log.w(REACT_CLASS, "Invalid expiration date format. Valid format is YYYY-mm-ddTHH:MM:SS, e.g. 2017-02-01T00:00:00. All times UTC.");
+            }
+        }
 
-    mainHandler.post(poller);
-  }
+        if (branchUniversalObjectMap.hasKey("keywords")) {
+            ReadableArray keywords = branchUniversalObjectMap.getArray("keywords");
+            for (int i=0; i<keywords.size(); ++i) {
+                branchUniversalObject.addKeyWord(keywords.getString(i));
+            }
+        }
 
-  private static Object getReadableMapObjectForKey(ReadableMap readableMap, String key) {
-    switch(readableMap.getType(key)) {
-      case Null:
-      return "Null";
-      case Boolean:
-      return readableMap.getBoolean(key);
-      case Number:
-      return readableMap.getDouble(key);
-      case String:
-      return readableMap.getString(key);
-      default:
-      return "Unsupported Type";
-    }
-  }
+        if(branchUniversalObjectMap.hasKey("metadata")) {
+            ReadableMap metadataMap = branchUniversalObjectMap.getMap("metadata");
+            ReadableMapKeySetIterator iterator = metadataMap.keySetIterator();
+            while (iterator.hasNextKey()) {
+                String metadataKey = iterator.nextKey();
+                Object metadataObject = getReadableMapObjectForKey(metadataMap, metadataKey);
+                branchUniversalObject.addContentMetadata(metadataKey, metadataObject.toString());
+            }
+        }
 
-  private static JSONObject convertMapToJson(ReadableMap readableMap) throws JSONException {
-    JSONObject object = new JSONObject();
-    ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
-    while (iterator.hasNextKey()) {
-      String key = iterator.nextKey();
-      switch (readableMap.getType(key)) {
-        case Null:
-        object.put(key, JSONObject.NULL);
-        break;
-        case Boolean:
-        object.put(key, readableMap.getBoolean(key));
-        break;
-        case Number:
-        object.put(key, readableMap.getDouble(key));
-        break;
-        case String:
-        object.put(key, readableMap.getString(key));
-        break;
-        case Map:
-        object.put(key, convertMapToJson(readableMap.getMap(key)));
-        break;
-        case Array:
-        object.put(key, convertArrayToJson(readableMap.getArray(key)));
-        break;
-      }
-    }
-    return object;
-  }
+        if (branchUniversalObjectMap.hasKey("type")) branchUniversalObject.setContentType(branchUniversalObjectMap.getString("type"));
 
-  private static JSONArray convertArrayToJson(ReadableArray readableArray) throws JSONException {
-    JSONArray array = new JSONArray();
-    for (int i = 0; i < readableArray.size(); i++) {
-      switch (readableArray.getType(i)) {
-        case Null:
-        break;
-        case Boolean:
-        array.put(readableArray.getBoolean(i));
-        break;
-        case Number:
-        array.put(readableArray.getDouble(i));
-        break;
-        case String:
-        array.put(readableArray.getString(i));
-        break;
-        case Map:
-        array.put(convertMapToJson(readableArray.getMap(i)));
-        break;
-        case Array:
-        array.put(convertArrayToJson(readableArray.getArray(i)));
-        break;
-      }
-    }
-    return array;
-  }
-
-  private static WritableMap convertJsonToMap(JSONObject jsonObject) {
-    if(jsonObject == null) {
-      return null;
+        return branchUniversalObject;
     }
 
-    WritableMap map = new WritableNativeMap();
-
-    try {
-      Iterator<String> iterator = jsonObject.keys();
-      while (iterator.hasNext()) {
-        String key = iterator.next();
-        Object value = jsonObject.get(key);
-        if (value instanceof JSONObject) {
-          map.putMap(key, convertJsonToMap((JSONObject) value));
-        } else if (value instanceof  JSONArray) {
-          map.putArray(key, convertJsonToArray((JSONArray) value));
-        } else if (value instanceof  Boolean) {
-          map.putBoolean(key, (Boolean) value);
-        } else if (value instanceof  Integer) {
-          map.putInt(key, (Integer) value);
-        } else if (value instanceof  Double) {
-          map.putDouble(key, (Double) value);
-        } else if (value instanceof String)  {
-          map.putString(key, (String) value);
-        } else if (value == null || value == JSONObject.NULL) {
-          map.putNull(key);
+    @ReactMethod
+    public void redeemRewards(int value, String bucket, Promise promise)
+    {
+        if (bucket == null) {
+            Branch.getInstance().redeemRewards(value, new RedeemRewardsListener(promise));
         } else {
-          map.putString(key, value.toString());
+            Branch.getInstance().redeemRewards(bucket, value, new RedeemRewardsListener(promise));
         }
-      }
-    } catch(JSONException ex) {
-      map.putString("error", "Failed to convert JSONObject to WriteableMap: " + ex.getMessage());
     }
 
-    return map;
-  }
-
-  private static WritableArray convertJsonToArray(JSONArray jsonArray) throws JSONException {
-    WritableArray array = new WritableNativeArray();
-
-    for (int i = 0; i < jsonArray.length(); i++) {
-      Object value = jsonArray.get(i);
-      if (value instanceof JSONObject) {
-        array.pushMap(convertJsonToMap((JSONObject) value));
-      } else if (value instanceof  JSONArray) {
-        array.pushArray(convertJsonToArray((JSONArray) value));
-      } else if (value instanceof  Boolean) {
-        array.pushBoolean((Boolean) value);
-      } else if (value instanceof  Integer) {
-        array.pushInt((Integer) value);
-      } else if (value instanceof  Double) {
-        array.pushDouble((Double) value);
-      } else if (value instanceof String)  {
-        array.pushString((String) value);
-      } else {
-        array.pushString(value.toString());
-      }
+    @ReactMethod
+    public void loadRewards(Promise promise)
+    {
+        Branch.getInstance().loadRewards(new LoadRewardsListener(promise));
     }
-    return array;
-  }
+
+    @ReactMethod
+    public void getCreditHistory(Promise promise)
+    {
+        Branch.getInstance().getCreditHistory(new CreditHistoryListener(promise));
+    }
+
+    protected class CreditHistoryListener implements Branch.BranchListResponseListener
+    {
+        private Promise _promise;
+
+        // Constructor that takes in a required callbackContext object
+        public CreditHistoryListener(Promise promise) {
+            this._promise = promise;
+        }
+
+        // Listener that implements BranchListResponseListener for getCreditHistory()
+        @Override
+        public void onReceivingResponse(JSONArray list, BranchError error) {
+            ArrayList<String> errors = new ArrayList<String>();
+            if (error == null) {
+                try {
+                    ReadableArray result = convertJsonToArray(list);
+                    this._promise.resolve(result);
+                } catch (JSONException err) {
+                    this._promise.reject(err.getMessage());
+                }
+            } else {
+                String errorMessage = error.getMessage();
+                Log.d(REACT_CLASS, errorMessage);
+                this._promise.reject(errorMessage);
+            }
+        }
+    }
+
+    protected class RedeemRewardsListener implements Branch.BranchReferralStateChangedListener
+    {
+        private Promise _promise;
+
+        public RedeemRewardsListener(Promise promise) {
+            this._promise = promise;
+        }
+
+        @Override
+        public void onStateChanged(boolean changed, BranchError error) {
+            if (error == null) {
+                WritableMap map = new WritableNativeMap();
+                map.putBoolean("changed", changed);
+                this._promise.resolve(map);
+            } else {
+                String errorMessage = error.getMessage();
+                Log.d(REACT_CLASS, errorMessage);
+                this._promise.reject(errorMessage);
+            }
+        }
+    }
+
+    protected class LoadRewardsListener implements Branch.BranchReferralStateChangedListener
+    {
+        private Promise _promise;
+
+        public LoadRewardsListener(Promise promise) {
+            this._promise = promise;
+        }
+
+        @Override
+        public void onStateChanged(boolean changed, BranchError error) {
+            if (error == null) {
+                int credits = Branch.getInstance().getCredits();
+                WritableMap map = new WritableNativeMap();
+                map.putInt("credits", credits);
+                this._promise.resolve(map);
+            } else {
+                String errorMessage = error.getMessage();
+                Log.d(REACT_CLASS, errorMessage);
+                this._promise.reject(errorMessage);
+            }
+        }
+    }
+
+    public void sendRNEvent(String eventName, @Nullable WritableMap params) {
+        // This should avoid the crash in getJSModule() at startup
+        // See also: https://github.com/walmartreact/react-native-orientation-listener/issues/8
+
+        ReactApplicationContext context = getReactApplicationContext();
+        Handler mainHandler = new Handler(context.getMainLooper());
+
+        Runnable poller = new Runnable() {
+
+            private Runnable init(ReactApplicationContext _context, Handler _mainHandler, String _eventName, WritableMap _params) {
+                mMainHandler = _mainHandler;
+                mEventName = _eventName;
+                mContext = _context;
+                mParams = _params;
+                return this;
+            }
+
+            final int pollDelayInMs = 100;
+            final int maxTries = 300;
+
+            int tries = 1;
+            String mEventName;
+            WritableMap mParams;
+            Handler mMainHandler;
+            ReactApplicationContext mContext;
+
+            @Override
+            public void run() {
+                try {
+                    Log.d(REACT_CLASS, "Catalyst instance poller try " + Integer.toString(tries));
+                    if (mContext.hasActiveCatalystInstance()) {
+                        Log.d(REACT_CLASS, "Catalyst instance active");
+                        mContext
+                                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                .emit(mEventName, mParams);
+                    } else {
+                        tries++;
+                        if (tries <= maxTries) {
+                            mMainHandler.postDelayed(this, pollDelayInMs);
+                        } else {
+                            Log.e(REACT_CLASS, "Could not get Catalyst instance");
+                        }
+                    }
+                }
+                catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }.init(context, mainHandler, eventName, params);
+
+        Log.d(REACT_CLASS, "sendRNEvent");
+
+        mainHandler.post(poller);
+    }
+
+    private static Object getReadableMapObjectForKey(ReadableMap readableMap, String key) {
+        switch(readableMap.getType(key)) {
+            case Null:
+                return "Null";
+            case Boolean:
+                return readableMap.getBoolean(key);
+            case Number:
+                return readableMap.getDouble(key);
+            case String:
+                return readableMap.getString(key);
+            default:
+                return "Unsupported Type";
+        }
+    }
+
+    private static JSONObject convertMapToJson(ReadableMap readableMap) throws JSONException {
+        JSONObject object = new JSONObject();
+        ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+        while (iterator.hasNextKey()) {
+            String key = iterator.nextKey();
+            switch (readableMap.getType(key)) {
+                case Null:
+                    object.put(key, JSONObject.NULL);
+                    break;
+                case Boolean:
+                    object.put(key, readableMap.getBoolean(key));
+                    break;
+                case Number:
+                    object.put(key, readableMap.getDouble(key));
+                    break;
+                case String:
+                    object.put(key, readableMap.getString(key));
+                    break;
+                case Map:
+                    object.put(key, convertMapToJson(readableMap.getMap(key)));
+                    break;
+                case Array:
+                    object.put(key, convertArrayToJson(readableMap.getArray(key)));
+                    break;
+            }
+        }
+        return object;
+    }
+
+    private static JSONArray convertArrayToJson(ReadableArray readableArray) throws JSONException {
+        JSONArray array = new JSONArray();
+        for (int i = 0; i < readableArray.size(); i++) {
+            switch (readableArray.getType(i)) {
+                case Null:
+                    break;
+                case Boolean:
+                    array.put(readableArray.getBoolean(i));
+                    break;
+                case Number:
+                    array.put(readableArray.getDouble(i));
+                    break;
+                case String:
+                    array.put(readableArray.getString(i));
+                    break;
+                case Map:
+                    array.put(convertMapToJson(readableArray.getMap(i)));
+                    break;
+                case Array:
+                    array.put(convertArrayToJson(readableArray.getArray(i)));
+                    break;
+            }
+        }
+        return array;
+    }
+
+    private static WritableMap convertJsonToMap(JSONObject jsonObject) {
+        if(jsonObject == null) {
+            return null;
+        }
+
+        WritableMap map = new WritableNativeMap();
+
+        try {
+            Iterator<String> iterator = jsonObject.keys();
+            while (iterator.hasNext()) {
+                String key = iterator.next();
+                Object value = jsonObject.get(key);
+                if (value instanceof JSONObject) {
+                    map.putMap(key, convertJsonToMap((JSONObject) value));
+                } else if (value instanceof  JSONArray) {
+                    map.putArray(key, convertJsonToArray((JSONArray) value));
+                } else if (value instanceof  Boolean) {
+                    map.putBoolean(key, (Boolean) value);
+                } else if (value instanceof  Integer) {
+                    map.putInt(key, (Integer) value);
+                } else if (value instanceof  Double) {
+                    map.putDouble(key, (Double) value);
+                } else if (value instanceof String)  {
+                    map.putString(key, (String) value);
+                } else if (value == null || value == JSONObject.NULL) {
+                    map.putNull(key);
+                } else {
+                    map.putString(key, value.toString());
+                }
+            }
+        } catch(JSONException ex) {
+            map.putString("error", "Failed to convert JSONObject to WriteableMap: " + ex.getMessage());
+        }
+
+        return map;
+    }
+
+    private static WritableArray convertJsonToArray(JSONArray jsonArray) throws JSONException {
+        WritableArray array = new WritableNativeArray();
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+            Object value = jsonArray.get(i);
+            if (value instanceof JSONObject) {
+                array.pushMap(convertJsonToMap((JSONObject) value));
+            } else if (value instanceof  JSONArray) {
+                array.pushArray(convertJsonToArray((JSONArray) value));
+            } else if (value instanceof  Boolean) {
+                array.pushBoolean((Boolean) value);
+            } else if (value instanceof  Integer) {
+                array.pushInt((Integer) value);
+            } else if (value instanceof  Double) {
+                array.pushDouble((Double) value);
+            } else if (value instanceof String)  {
+                array.pushString((String) value);
+            } else {
+                array.pushString(value.toString());
+            }
+        }
+        return array;
+    }
 }

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -33,6 +33,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static final String NATIVE_INIT_SESSION_FINISHED_EVENT = "onInitSessionFinished";
     private static final String RN_INIT_SESSION_EVENT = "RNBranch.initSessionSuccess";
     private static final String IDENT_FIELD_NAME = "ident";
+    public static final String UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE = "RNBranchUniversalObjectNotFound";
 
     private static JSONObject initSessionResult = null;
     private BroadcastReceiver mInitSessionEventReceiver = null;
@@ -326,9 +327,9 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
         // This is extremely unlikely and basically a logic error.
         if (universalObject == null) {
-            final String errorMessage = "BranchUniversalObject not found for ident " + ident;
+            final String errorMessage = "BranchUniversalObject not found for ident " + ident + ". Do not reuse a BUO after calling release() in JS. Create a new instance instead.";
 
-            promise.reject(errorMessage);
+            promise.reject(UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE, errorMessage);
 
             Log.e(REACT_CLASS, errorMessage);
         }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -5,22 +5,27 @@
 #import "BranchLinkProperties+RNBranch.h"
 #import "BranchUniversalObject+RNBranch.h"
 
+static NSDictionary *initSessionWithLaunchOptionsResult;
+static NSURL *sourceUrl;
+static Branch *branchInstance;
+
+static NSString * const initSessionWithLaunchOptionsFinishedEventName = @"initSessionWithLaunchOptionsFinished";
+static NSString * const IdentFieldName = @"ident";
+
+// These are only really exposed to the JS layer, so keep them internal for now.
+static NSString * const RNBranchErrorDomain = @"RNBranchErrorDomain";
+static NSInteger const RNBranchUniversalObjectNotFoundError = 1;
+
 #pragma mark - Private RNBranch declarations
 
 @interface RNBranch()
 @property (nonatomic, readonly) UIViewController *currentViewController;
 @property (nonatomic) NSMutableDictionary<NSString *, BranchUniversalObject *> *universalObjectMap;
-@property (nonatomic) NSDictionary *initSessionWithLaunchOptionsResult;
-@property (nonatomic) NSURL *sourceUrl;
-@property (nonatomic) Branch *branchInstance;
 @end
 
 #pragma mark - RNBranch implementation
 
 @implementation RNBranch
-
-NSString const * const initSessionWithLaunchOptionsFinishedEventName = @"initSessionWithLaunchOptionsFinished";
-NSString const * const IdentFieldName = @"ident";
 
 @synthesize bridge = _bridge;
 
@@ -29,38 +34,38 @@ RCT_EXPORT_MODULE();
 #pragma mark - Class methods
 
 + (void)useTestInstance {
-    self.branchInstance = [Branch getTestInstance];
+    branchInstance = [Branch getTestInstance];
 }
 
 //Called by AppDelegate.m -- stores initSession result in static variables and raises initSessionFinished event that's captured by the RNBranch instance to emit it to React Native
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable {
-    self.sourceUrl = launchOptions[UIApplicationLaunchOptionsURLKey];
+    sourceUrl = launchOptions[UIApplicationLaunchOptionsURLKey];
 
-    if (!self.branchInstance) {
-        self.branchInstance = [Branch getInstance];
+    if (!branchInstance) {
+        branchInstance = [Branch getInstance];
     }
-    [self.branchInstance initSessionWithLaunchOptions:launchOptions isReferrable:isReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
+    [branchInstance initSessionWithLaunchOptions:launchOptions isReferrable:isReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
         NSString *errorMessage = error.localizedDescription;
-        
-        self.initSessionWithLaunchOptionsResult = @{
+
+        initSessionWithLaunchOptionsResult = @{
                                                @"params": params && params[@"~id"] ? params : [NSNull null],
                                                @"error": errorMessage ?: [NSNull null],
-                                               @"uri": self.sourceUrl.absoluteString ?: [NSNull null]
+                                               @"uri": sourceUrl.absoluteString ?: [NSNull null]
                                                };
-        
-        [[NSNotificationCenter defaultCenter] postNotificationName:initSessionWithLaunchOptionsFinishedEventName object:self.initSessionWithLaunchOptionsResult];
+
+        [[NSNotificationCenter defaultCenter] postNotificationName:initSessionWithLaunchOptionsFinishedEventName object:initSessionWithLaunchOptionsResult];
     }];
 }
 
 + (BOOL)handleDeepLink:(NSURL *)url {
-    self.sourceUrl = url;
-    BOOL handled = [self.branchInstance handleDeepLink:url];
+    sourceUrl = url;
+    BOOL handled = [branchInstance handleDeepLink:url];
     return handled;
 }
 
 + (BOOL)continueUserActivity:(NSUserActivity *)userActivity {
-    self.sourceUrl = userActivity.webpageURL;
-    return [self.branchInstance continueUserActivity:userActivity];
+    sourceUrl = userActivity.webpageURL;
+    return [branchInstance continueUserActivity:userActivity];
 }
 
 #pragma mark - Object lifecycle
@@ -70,10 +75,10 @@ RCT_EXPORT_MODULE();
 
     if (self) {
         _universalObjectMap = [NSMutableDictionary dictionary];
-    
+
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onInitSessionFinished:) name:initSessionWithLaunchOptionsFinishedEventName object:nil];
     }
-    
+
     return self;
 }
 
@@ -94,12 +99,12 @@ RCT_EXPORT_MODULE();
 
 - (void) onInitSessionFinished:(NSNotification*) notification {
     id notificationObject = notification.object;
-    
+
     // If there is an error, fire error event
     if (notificationObject[@"error"] != [NSNull null]) {
         [self.bridge.eventDispatcher sendAppEventWithName:@"RNBranch.initSessionError" body:notificationObject];
     }
-    
+
     // otherwise notify the session is finished
     else {
         [self.bridge.eventDispatcher sendAppEventWithName:@"RNBranch.initSessionSuccess" body:notificationObject];
@@ -109,21 +114,30 @@ RCT_EXPORT_MODULE();
 - (BranchLinkProperties*) createLinkProperties:(NSDictionary *)linkPropertiesMap withControlParams:(NSDictionary *)controlParamsMap
 {
     BranchLinkProperties *linkProperties = [[BranchLinkProperties alloc] initWithMap:linkPropertiesMap];
-    
+
     linkProperties.controlParams = controlParamsMap;
     return linkProperties;
 }
 
-- (BranchUniversalObject *)findUniversalObjectWithIdentifier:(NSString *)identifier rejecter:(RCTPromiseRejectBlock)reject
+- (BranchUniversalObject *)findUniversalObjectWithIdent:(NSString *)ident rejecter:(RCTPromiseRejectBlock)reject
 {
-    BranchUniversalObject *universalObject = self.universalObjectMap[identifier];
+    BranchUniversalObject *universalObject = self.universalObjectMap[ident];
 
+    // This is extremely unlikely and amounts to a logic error.
     if (!universalObject) {
-        NSString *errorMessage = [NSString stringWithFormat:@"BranchUniversalObject for identifier %@ not found", identifier];
-        RCTLogError(errorMessage);
-        reject(errorMessage);
-    }
+        NSString *errorMessage = [NSString stringWithFormat:@"BranchUniversalObject for ident %@ not found", ident];
 
+        NSError *error = [NSError errorWithDomain:RNBranchErrorDomain
+                                             code:RNBranchUniversalObjectNotFoundError
+                                         userInfo:@{IdentFieldName : ident,
+                                                     NSLocalizedDescriptionKey: errorMessage
+                                                     }];
+        
+        RCTLogError(@"%@", error.debugDescription);
+
+        reject(@"RNBranch::Error", errorMessage, error);
+    }
+    
     return universalObject;
 }
 
@@ -132,48 +146,48 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(
                   redeemInitSessionResult:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
-                  ){
-    resolve(self.initSessionWithLaunchOptionsResult ? self.initSessionWithLaunchOptionsResult : [NSNull null]);
-    self.initSessionWithLaunchOptionsResult = [NSNull null];
-    self.sourceUrl = nil;
+                  ) {
+    resolve(initSessionWithLaunchOptionsResult ? initSessionWithLaunchOptionsResult : [NSNull null]);
+    initSessionWithLaunchOptionsResult = [NSNull null];
+    sourceUrl = nil;
 }
 
 RCT_EXPORT_METHOD(
                   setDebug
-                  ){
-    [self.branchInstance setDebug];
+                  ) {
+    [branchInstance setDebug];
 }
 
 RCT_EXPORT_METHOD(
                   getLatestReferringParams:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
-                  ){
-    resolve([self.branchInstance getLatestReferringParams]);
+                  ) {
+    resolve([branchInstance getLatestReferringParams]);
 }
 
 RCT_EXPORT_METHOD(
                   getFirstReferringParams:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
-                  ){
-    resolve([self.branchInstance getFirstReferringParams]);
+                  ) {
+    resolve([branchInstance getFirstReferringParams]);
 }
 
 RCT_EXPORT_METHOD(
                   setIdentity:(NSString *)identity
-                  ){
-    [self.branchInstance setIdentity:identity];
+                  ) {
+    [branchInstance setIdentity:identity];
 }
 
 RCT_EXPORT_METHOD(
                   logout
-                  ){
-    [self.branchInstance logout];
+                  ) {
+    [branchInstance logout];
 }
 
 RCT_EXPORT_METHOD(
                   userCompletedAction:(NSString *)event withState:(NSDictionary *)appState
-                  ){
-    [self.branchInstance userCompletedAction:event withState:appState];
+                  ) {
+    [branchInstance userCompletedAction:event withState:appState];
 }
 
 RCT_EXPORT_METHOD(
@@ -183,8 +197,8 @@ RCT_EXPORT_METHOD(
                   withControlParams:(NSDictionary *)controlParamsMap
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
-    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdentifier:identifier rejecter:reject];
+                  ) {
+    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdent:identifier rejecter:reject];
     if (!branchUniversalObject) return;
 
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -192,27 +206,27 @@ RCT_EXPORT_METHOD(
         if (shareOptionsMap && shareOptionsMap[@"emailSubject"]) {
             mutableControlParams[@"$email_subject"] = shareOptionsMap[@"emailSubject"];
         }
-        
+
         BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:mutableControlParams];
-        
+
         [branchUniversalObject showShareSheetWithLinkProperties:linkProperties
                                                    andShareText:shareOptionsMap[@"messageBody"]
                                              fromViewController:self.currentViewController
-                                                     completionWithError:^(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable activityError){
-                                                         if (activityError) {
-                                                             NSString *errorCodeString = [NSString stringWithFormat:@"%ld", (long)activityError.code];
-                                                             reject(errorCodeString, activityError.localizedDescription, activityError);
-                                                             return;
-                                                         }
+                                            completionWithError:^(NSString * _Nullable activityType, BOOL completed, NSError * _Nullable activityError){
+                                                if (activityError) {
+                                                    NSString *errorCodeString = [NSString stringWithFormat:@"%ld", (long)activityError.code];
+                                                    reject(errorCodeString, activityError.localizedDescription, activityError);
+                                                    return;
+                                                }
 
-                                                         NSDictionary *result = @{
-                                                                                  @"channel" : activityType ?: [NSNull null],
-                                                                                  @"completed" : @(completed),
-                                                                                  @"error" : [NSNull null]
-                                                                                  };
-                                                         
-                                                         resolve(result);
-                                                     }];
+                                                NSDictionary *result = @{
+                                                                         @"channel" : activityType ?: [NSNull null],
+                                                                         @"completed" : @(completed),
+                                                                         @"error" : [NSNull null]
+                                                                         };
+
+                                                resolve(result);
+                                            }];
     });
 }
 
@@ -220,8 +234,8 @@ RCT_EXPORT_METHOD(
                   registerView:(NSString *)identifier
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
-    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdentifier:identifier rejecter:reject];
+                  ) {
+    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdent:identifier rejecter:reject];
     if (!branchUniversalObject) return;
 
     [branchUniversalObject registerViewWithCallback:^(NSDictionary *params, NSError *error) {
@@ -239,12 +253,12 @@ RCT_EXPORT_METHOD(
                   withControlParams:(NSDictionary *)controlParamsMap
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
-    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdentifier:identifier rejecter:reject];
+                  ) {
+    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdent:identifier rejecter:reject];
     if (!branchUniversalObject) return;
 
     BranchLinkProperties *linkProperties = [self createLinkProperties:linkPropertiesMap withControlParams:controlParamsMap];
-    
+
     [branchUniversalObject getShortUrlWithLinkProperties:linkProperties andCallback:^(NSString *url, NSError *error) {
         if (!error) {
             RCTLogInfo(@"RNBranch Success");
@@ -259,8 +273,8 @@ RCT_EXPORT_METHOD(
                   listOnSpotlight:(NSString *)identifier
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
-    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdentifier:identifier rejecter:reject];
+                  ) {
+    BranchUniversalObject *branchUniversalObject = [self findUniversalObjectWithIdent:identifier rejecter:reject];
     if (!branchUniversalObject) return;
 
     [branchUniversalObject listOnSpotlightWithCallback:^(NSString *string, NSError *error) {
@@ -278,13 +292,13 @@ RCT_EXPORT_METHOD(
                   getShortUrl:(NSDictionary *)linkPropertiesMap
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
+                  ) {
     NSString *feature = linkPropertiesMap[@"feature"];
     NSString *channel = linkPropertiesMap[@"channel"];
     NSString *stage = linkPropertiesMap[@"stage"];
     NSArray *tags = linkPropertiesMap[@"tags"];
-    
-    [self.branchInstance getShortURLWithParams:linkPropertiesMap
+
+    [branchInstance getShortURLWithParams:linkPropertiesMap
                                   andTags:tags
                                andChannel:channel
                                andFeature:feature
@@ -301,8 +315,8 @@ RCT_EXPORT_METHOD(
 RCT_EXPORT_METHOD(
                   loadRewards:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
-    [self.branchInstance loadRewardsWithCallback:^(BOOL changed, NSError *error) {
+                  ) {
+    [branchInstance loadRewardsWithCallback:^(BOOL changed, NSError *error) {
         if(!error) {
             int credits = (int)[branchInstance getCredits];
             resolve(@{@"credits": @(credits)});
@@ -318,9 +332,9 @@ RCT_EXPORT_METHOD(
                   inBucket:(NSString *)bucket
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
+                  ) {
     if (bucket) {
-        [self.branchInstance redeemRewards:amount forBucket:bucket callback:^(BOOL changed, NSError *error) {
+        [branchInstance redeemRewards:amount forBucket:bucket callback:^(BOOL changed, NSError *error) {
             if (!error) {
                 resolve(@{@"changed": @(changed)});
             } else {
@@ -329,7 +343,7 @@ RCT_EXPORT_METHOD(
             }
         }];
     } else {
-        [self.branchInstance redeemRewards:amount callback:^(BOOL changed, NSError *error) {
+        [branchInstance redeemRewards:amount callback:^(BOOL changed, NSError *error) {
             if (!error) {
                 resolve(@{@"changed": @(changed)});
             } else {
@@ -343,8 +357,8 @@ RCT_EXPORT_METHOD(
 RCT_EXPORT_METHOD(
                   getCreditHistory:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
-                  ){
-    [self.branchInstance getCreditHistoryWithCallback:^(NSArray *list, NSError *error) {
+                  ) {
+    [branchInstance getCreditHistoryWithCallback:^(NSArray *list, NSError *error) {
         if (!error) {
             resolve(list);
         } else {
@@ -357,7 +371,8 @@ RCT_EXPORT_METHOD(
 RCT_EXPORT_METHOD(
                   createUniversalObject:(NSDictionary *)universalObjectProperties
                   resolver:(RCTPromiseResolveBlock)resolve
-) {
+                  rejecter:(__unused RCTPromiseRejectBlock)reject
+                  ) {
     BranchUniversalObject *universalObject = [[BranchUniversalObject alloc] initWithMap:universalObjectProperties];
     NSString *identifier = [NSUUID UUID].UUIDString;
     self.universalObjectMap[identifier] = universalObject;

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -11,7 +11,7 @@
 @property (nonatomic, readonly) UIViewController *currentViewController;
 @property (nonatomic) NSMutableDictionary<NSString *, BranchUniversalObject *> *universalObjectMap;
 @property (nonatomic) NSDictionary *initSessionWithLaunchOptionsResult;
-@property (nonatomic) NSString *sourceUrl;
+@property (nonatomic) NSURL *sourceUrl;
 @property (nonatomic) Branch *branchInstance;
 @end
 
@@ -33,6 +33,8 @@ RCT_EXPORT_MODULE();
 
 //Called by AppDelegate.m -- stores initSession result in static variables and raises initSessionFinished event that's captured by the RNBranch instance to emit it to React Native
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable {
+    self.sourceUrl = launchOptions[UIApplicationLaunchOptionsURLKey];
+
     if (!self.branchInstance) {
         self.branchInstance = [Branch getInstance];
     }
@@ -42,7 +44,7 @@ RCT_EXPORT_MODULE();
         self.initSessionWithLaunchOptionsResult = @{
                                                @"params": params && params[@"~id"] ? params : [NSNull null],
                                                @"error": errorMessage ?: [NSNull null],
-                                               @"uri": self.sourceUrl ?: [NSNull null]
+                                               @"uri": self.sourceUrl.absoluteString ?: [NSNull null]
                                                };
         
         [[NSNotificationCenter defaultCenter] postNotificationName:initSessionWithLaunchOptionsFinishedEventName object:self.initSessionWithLaunchOptionsResult];
@@ -50,13 +52,13 @@ RCT_EXPORT_MODULE();
 }
 
 + (BOOL)handleDeepLink:(NSURL *)url {
-    self.sourceUrl = url.absoluteString ?: [NSNull null];
+    self.sourceUrl = url;
     BOOL handled = [self.branchInstance handleDeepLink:url];
     return handled;
 }
 
 + (BOOL)continueUserActivity:(NSUserActivity *)userActivity {
-    self.sourceUrl = userActivity.webpageURL.absoluteString ?: [NSNull null];
+    self.sourceUrl = userActivity.webpageURL;
     return [self.branchInstance continueUserActivity:userActivity];
 }
 

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -125,15 +125,15 @@ RCT_EXPORT_MODULE();
 
     // This is extremely unlikely and amounts to a logic error.
     if (!universalObject) {
-        NSString *errorMessage = [NSString stringWithFormat:@"BranchUniversalObject for ident %@ not found", ident];
+        NSString *errorMessage = [NSString stringWithFormat:@"BranchUniversalObject for ident %@ not found. Do not reuse a BUO after calling release() in JS. Create a new instance instead.", ident];
 
         NSError *error = [NSError errorWithDomain:RNBranchErrorDomain
                                              code:RNBranchUniversalObjectNotFoundError
                                          userInfo:@{IdentFieldName : ident,
-                                                     NSLocalizedDescriptionKey: errorMessage
-                                                     }];
+                                                    NSLocalizedDescriptionKey: errorMessage
+                                                    }];
         
-        RCTLogError(@"%@", error.debugDescription);
+        RCTLogError(@"%@", error.localizedDescription);
 
         reject(@"RNBranch::Error", errorMessage, error);
     }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -343,15 +343,6 @@ RCT_EXPORT_METHOD(
     }];
 }
 
-/*
- * TODO: Should this be reference-counted? It's not hard to imagine an app creating multiple instances of BUO
- * in different code units and holding on to them. For example, a view that shows general information about some
- * content could display a modal view with details about the same content. When routing the link, it would
- * probably show the general view. Maybe there would be the same share option from both views, however, and a
- * dev might call registerView() in each one. Properly calling release() in each place would make a reference
- * count necessary in order for things to work after dismissing the modal.
- */
-
 RCT_EXPORT_METHOD(
                   createUniversalObject:(NSDictionary *)universalObjectProperties
                   resolver:(RCTPromiseResolveBlock)resolve

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -2,7 +2,7 @@ import { NativeModules, Platform } from 'react-native'
 
 const { RNBranch } = NativeModules
 
-export default function createBranchUniversalObject(identifier, options = {}) {
+export default async function createBranchUniversalObject(identifier, options = {}) {
   if (typeof identifier !== 'string') throw new Error('react-native-branch: identifier must be a string')
 
   const branchUniversalObject = {
@@ -11,7 +11,7 @@ export default function createBranchUniversalObject(identifier, options = {}) {
     ...options
   }
 
-  RNBranch.createUniversalObject(branchUniversalObject)
+  let { ident } = await RNBranch.createUniversalObject(branchUniversalObject)
 
   return {
     showShareSheet(shareOptions = {}, linkProperties = {}, controlParams = {}) {
@@ -27,20 +27,20 @@ export default function createBranchUniversalObject(identifier, options = {}) {
         ...linkProperties,
       }
 
-      return RNBranch.showShareSheet(identifier, shareOptions, linkProperties, controlParams)
+      return RNBranch.showShareSheet(ident, shareOptions, linkProperties, controlParams)
     },
     registerView() {
-      return RNBranch.registerView(identifier)
+      return RNBranch.registerView(ident)
     },
     generateShortUrl(linkProperties = {}, controlParams = {}) {
-      return RNBranch.generateShortUrl(identifier, linkProperties, controlParams)
+      return RNBranch.generateShortUrl(ident, linkProperties, controlParams)
     },
     listOnSpotlight() {
       if (Platform.OS !== 'ios') return Promise.resolve()
-      return RNBranch.listOnSpotlight(identifier)
+      return RNBranch.listOnSpotlight(ident)
     },
     release() {
-      RNBranch.releaseUniversalObject(identifier)
+      RNBranch.releaseUniversalObject(ident)
     }
   }
 }

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -11,7 +11,7 @@ export default async function createBranchUniversalObject(identifier, options = 
     ...options
   }
 
-  let { ident } = await RNBranch.createUniversalObject(branchUniversalObject)
+  const { ident } = await RNBranch.createUniversalObject(branchUniversalObject)
 
   return {
     showShareSheet(shareOptions = {}, linkProperties = {}, controlParams = {}) {

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -11,6 +11,8 @@ export default function createBranchUniversalObject(identifier, options = {}) {
     ...options
   }
 
+  RNBranch.createUniversalObject(branchUniversalObject)
+
   return {
     showShareSheet(shareOptions = {}, linkProperties = {}, controlParams = {}) {
       shareOptions = {
@@ -25,17 +27,20 @@ export default function createBranchUniversalObject(identifier, options = {}) {
         ...linkProperties,
       }
 
-      return RNBranch.showShareSheet(branchUniversalObject, shareOptions, linkProperties, controlParams)
+      return RNBranch.showShareSheet(identifier, shareOptions, linkProperties, controlParams)
     },
     registerView() {
-      return RNBranch.registerView(branchUniversalObject)
+      return RNBranch.registerView(identifier)
     },
     generateShortUrl(linkProperties = {}, controlParams = {}) {
-      return RNBranch.generateShortUrl(branchUniversalObject, linkProperties, controlParams)
+      return RNBranch.generateShortUrl(identifier, linkProperties, controlParams)
     },
     listOnSpotlight() {
       if (Platform.OS !== 'ios') return Promise.resolve()
-      return RNBranch.listOnSpotlight(branchUniversalObject)
+      return RNBranch.listOnSpotlight(identifier)
+    },
+    release() {
+      RNBranch.releaseUniversalObject(identifier)
     }
   }
 }

--- a/testbed/testbed_carthage/src/BranchMethods.js
+++ b/testbed/testbed_carthage/src/BranchMethods.js
@@ -20,6 +20,7 @@ class BranchMethods extends Component {
   createBranchUniversalObject = async () => {
     try {
       let result = await branch.createBranchUniversalObject('abc', defaultBUO)
+      if (this.buo) this.buo.release()
       this.buo = result
       console.log('createBranchUniversalObject', result)
       this.addResult('success', 'createBranchUniversalObject', result)

--- a/testbed/testbed_cocoapods/android/app/app.iml
+++ b/testbed/testbed_cocoapods/android/app/app.iml
@@ -83,6 +83,8 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
@@ -97,11 +99,13 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.soloader/soloader/0.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/org.webkit/android-jsc/r174650/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
@@ -143,9 +147,9 @@
     <orderEntry type="library" exported="" name="fresco-0.8.1" level="project" />
     <orderEntry type="library" exported="" name="imagepipeline-okhttp-0.8.1" level="project" />
     <orderEntry type="library" exported="" name="bolts-android-1.1.4" level="project" />
-    <orderEntry type="library" exported="" name="library-2.5.7" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.0.1" level="project" />
     <orderEntry type="library" exported="" name="drawee-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="library-2.5.8" level="project" />
     <orderEntry type="library" exported="" name="react-native-0.20.1" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
   </component>

--- a/testbed/testbed_cocoapods/src/BranchMethods.js
+++ b/testbed/testbed_cocoapods/src/BranchMethods.js
@@ -20,6 +20,7 @@ class BranchMethods extends Component {
   createBranchUniversalObject = async () => {
     try {
       let result = await branch.createBranchUniversalObject('abc', defaultBUO)
+      if (this.buo) this.buo.release()
       this.buo = result
       console.log('createBranchUniversalObject', result)
       this.addResult('success', 'createBranchUniversalObject', result)


### PR DESCRIPTION
This is a significant internal change to the native layers that establishes a one-to-one relationship between the BranchUniversalObject in each native layer (Android and iOS) and the JS object returned by `branch.createBranchUniversalObject`. In current releases, in a simple snippet like this:

```js
let universalObject = branch.createBranchUniversalObject(...)
universalObject.registerView()
universalObject.showShareSheet(...)
```

Each time a method is called on the `universalObject`, a new temporary native instance of BranchUniversalObject is instantiated using the same parameters. The corresponding method is called on that instance, and then the instance is discarded. This is not in line with Branch's recommended best practices. It is mainly inefficient, but there may also be unintended consequences.

To remedy this, a new method was exposed from the native module to the package's JS: `RNBranch.createUniversalObject`. This method actually instantiates a BranchUniversalObject in the native layer, assigns it a unique identifier, stores the reference in a hash/dictionary using the identifier as a key and returns the identifier to JS. Future calls to the JS methods no longer pass in all the parameters for the BUO, but only the identifier. The native layer then finds the native BUO instance using the supplied identifier and executes the corresponding method on the stored instance.

The main architectural weakness here is that there is no easy way to determine when a JS object is garbage-collected, like a `finalize` in Java or `deinit` in Swift. Hence, there is the potential for the hash/dictionary used by the native layer to track these objects to grow without limit. However:

1. As a practical matter, this does not represent much memory. A BUO does not represent a large memory allocation, and during the lifetime of an app, it is unlikely to produce more than dozens of instances, at the outside. This potential leak does not represent dramatic memory growth in an actual application.
2. A `release` method has been provided for apps concerned about this issue. Calling this method simply removes the native instance from the hash/dictionary, resulting in the corresponding memory being reclaimed. It's necessary for callers of `release()` to remember not to use the BUO again after calling the method. Example:

```js
let universalObject = branch.createBranchUniversalObject(...)
universalObject.registerView()
universalObject.showShareSheet(...)
universalObject.release() // <= discard native BUO once finished

// illegal. will result in a promise rejection when the native BUO is not found.
// create a new instance instead
universalObject.generateShortUrl(...) 
```

It would be nice to find an automated solution, but I'm not sure what it would be.

This change also fixes a problem where the `uri` field would not be populated in the `branch.subscribe` callback if the app was launched from a link.

Further notes:

- The unique identifier shows up as a field called `ident` in the JS object. This cannot be hidden from callers. It does not conflict with other fields in the JS BUO returned by the JS creation method.
- The native layers generate UUIDs to use as identifiers. These are returned in the `ident` field. There are plenty of options, but this guarantees uniqueness and makes use of system utilities. A shorter `ident` field could be produced just using sequential integers, say. They only need to be unique during the lifetime of the app.