### PR TITLE
Age cached BUOs

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/AgingHash.java
+++ b/android/src/main/java/io/branch/rnbranch/AgingHash.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
  * Created by jdee on 3/8/17.
  */
 
-public class AgingHash<KeyType, ValueType> extends Object {
+public class AgingHash<KeyType, ValueType> {
     private long mTtl;
     private HashMap<KeyType, AgingItem<ValueType>> mHash = new HashMap<>();
 

--- a/android/src/main/java/io/branch/rnbranch/AgingHash.java
+++ b/android/src/main/java/io/branch/rnbranch/AgingHash.java
@@ -8,11 +8,15 @@ import java.util.Iterator;
  */
 
 public class AgingHash<KeyType, ValueType> {
-    private long mTtl;
+    private long mTtlMillis;
     private HashMap<KeyType, AgingItem<ValueType>> mHash = new HashMap<>();
 
-    public AgingHash(long ttl) {
-        mTtl = ttl;
+    public AgingHash(long ttlMillis) {
+        mTtlMillis = ttlMillis;
+    }
+
+    public long getTtlMillis() {
+        return mTtlMillis;
     }
 
     public void put(KeyType key, ValueType value) {
@@ -40,7 +44,7 @@ public class AgingHash<KeyType, ValueType> {
         while (it.hasNext()) {
             HashMap.Entry pair = (HashMap.Entry) it.next();
             AgingItem<ValueType> item = (AgingItem) pair.getValue();
-            if (now - item.getAccessTime() >= mTtl) {
+            if (now - item.getAccessTime() >= mTtlMillis) {
                 it.remove();
             }
         }

--- a/android/src/main/java/io/branch/rnbranch/AgingHash.java
+++ b/android/src/main/java/io/branch/rnbranch/AgingHash.java
@@ -1,0 +1,48 @@
+package io.branch.rnbranch;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+/**
+ * Created by jdee on 3/8/17.
+ */
+
+public class AgingHash<KeyType, ValueType> extends Object {
+    private long mTtl;
+    private HashMap<KeyType, AgingItem<ValueType>> mHash = new HashMap<>();
+
+    public AgingHash(long ttl) {
+        mTtl = ttl;
+    }
+
+    public void put(KeyType key, ValueType value) {
+        ageItems();
+
+        AgingItem<ValueType> item = new AgingItem<>(value);
+        mHash.put(key, item);
+    }
+
+    public ValueType get(KeyType key) {
+        AgingItem<ValueType> item = mHash.get(key);
+        if (item == null) return null;
+
+        return item.get();
+    }
+
+    public void remove(KeyType key) {
+        mHash.remove(key);
+    }
+
+    private void ageItems() {
+        long now = System.currentTimeMillis();
+
+        Iterator it = mHash.entrySet().iterator();
+        while (it.hasNext()) {
+            HashMap.Entry pair = (HashMap.Entry) it.next();
+            AgingItem<ValueType> item = (AgingItem) pair.getValue();
+            if (now - item.getAccessTime() >= mTtl) {
+                it.remove();
+            }
+        }
+    }
+}

--- a/android/src/main/java/io/branch/rnbranch/AgingItem.java
+++ b/android/src/main/java/io/branch/rnbranch/AgingItem.java
@@ -1,0 +1,23 @@
+package io.branch.rnbranch;
+
+/**
+ * Created by jdee on 3/8/17.
+ */
+
+public class AgingItem<ValueType> extends Object {
+    private long mAccessTime = System.currentTimeMillis();
+    private ValueType mItem = null;
+
+    public AgingItem(ValueType item) {
+        mItem = item;
+    }
+
+    public ValueType get() {
+        mAccessTime = System.currentTimeMillis();
+        return mItem;
+    }
+
+    public long getAccessTime() {
+        return mAccessTime;
+    }
+}

--- a/android/src/main/java/io/branch/rnbranch/AgingItem.java
+++ b/android/src/main/java/io/branch/rnbranch/AgingItem.java
@@ -4,7 +4,7 @@ package io.branch.rnbranch;
  * Created by jdee on 3/8/17.
  */
 
-public class AgingItem<ValueType> extends Object {
+public class AgingItem<ValueType> {
     private long mAccessTime = System.currentTimeMillis();
     private ValueType mItem = null;
 

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -33,7 +33,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static final String NATIVE_INIT_SESSION_FINISHED_EVENT = "onInitSessionFinished";
     private static final String RN_INIT_SESSION_EVENT = "RNBranch.initSessionSuccess";
     private static final String IDENT_FIELD_NAME = "ident";
-    public static final String UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE = "RNBranchUniversalObjectNotFound";
+    public static final String UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE = "RNBranch::Error::BUONotFound";
     private static final long AGING_HASH_TTL = 3600000;
 
     private static JSONObject initSessionResult = null;
@@ -329,10 +329,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         // This is extremely unlikely and basically a logic error.
         if (universalObject == null) {
             final String errorMessage = "BranchUniversalObject not found for ident " + ident + ". Do not reuse a BUO after calling release() in JS. Create a new instance instead.";
-
             promise.reject(UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE, errorMessage);
-
-            Log.e(REACT_CLASS, errorMessage);
         }
 
         return universalObject;

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -34,6 +34,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static final String RN_INIT_SESSION_EVENT = "RNBranch.initSessionSuccess";
     private static final String IDENT_FIELD_NAME = "ident";
     public static final String UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE = "RNBranchUniversalObjectNotFound";
+    private static final long AGING_HASH_TTL = 3600000;
 
     private static JSONObject initSessionResult = null;
     private BroadcastReceiver mInitSessionEventReceiver = null;
@@ -41,7 +42,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static Activity mActivity = null;
     private static Branch mBranch = null;
 
-    private HashMap<String, BranchUniversalObject> mUniversalObjectMap = new HashMap<>();
+    private AgingHash<String, BranchUniversalObject> mUniversalObjectMap = new AgingHash<>(AGING_HASH_TTL);
 
     public static void initSession(final Uri uri, Activity reactActivity) {
         mBranch = Branch.getInstance(reactActivity.getApplicationContext());

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -144,6 +144,7 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Methods exported to React Native
 
+#pragma mark redeemInitSessionResult
 RCT_EXPORT_METHOD(
                   redeemInitSessionResult:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
@@ -153,12 +154,14 @@ RCT_EXPORT_METHOD(
     sourceUrl = nil;
 }
 
+#pragma mark setDebug
 RCT_EXPORT_METHOD(
                   setDebug
                   ) {
     [branchInstance setDebug];
 }
 
+#pragma mark getLatestReferringParams
 RCT_EXPORT_METHOD(
                   getLatestReferringParams:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
@@ -166,6 +169,7 @@ RCT_EXPORT_METHOD(
     resolve([branchInstance getLatestReferringParams]);
 }
 
+#pragma mark getFirstReferringParams
 RCT_EXPORT_METHOD(
                   getFirstReferringParams:(RCTPromiseResolveBlock)resolve
                   rejecter:(__unused RCTPromiseRejectBlock)reject
@@ -173,24 +177,28 @@ RCT_EXPORT_METHOD(
     resolve([branchInstance getFirstReferringParams]);
 }
 
+#pragma mark setIdentity
 RCT_EXPORT_METHOD(
                   setIdentity:(NSString *)identity
                   ) {
     [branchInstance setIdentity:identity];
 }
 
+#pragma mark logout
 RCT_EXPORT_METHOD(
                   logout
                   ) {
     [branchInstance logout];
 }
 
+#pragma mark userCompletedAction
 RCT_EXPORT_METHOD(
                   userCompletedAction:(NSString *)event withState:(NSDictionary *)appState
                   ) {
     [branchInstance userCompletedAction:event withState:appState];
 }
 
+#pragma mark showShareSheet
 RCT_EXPORT_METHOD(
                   showShareSheet:(NSString *)identifier
                   withShareOptions:(NSDictionary *)shareOptionsMap
@@ -231,6 +239,7 @@ RCT_EXPORT_METHOD(
     });
 }
 
+#pragma mark registerView
 RCT_EXPORT_METHOD(
                   registerView:(NSString *)identifier
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -248,6 +257,7 @@ RCT_EXPORT_METHOD(
     }];
 }
 
+#pragma mark generateShortUrl
 RCT_EXPORT_METHOD(
                   generateShortUrl:(NSString *)identifier
                   withLinkProperties:(NSDictionary *)linkPropertiesMap
@@ -270,6 +280,7 @@ RCT_EXPORT_METHOD(
     }];
 }
 
+#pragma mark listOnSpotlight
 RCT_EXPORT_METHOD(
                   listOnSpotlight:(NSString *)identifier
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -289,6 +300,7 @@ RCT_EXPORT_METHOD(
 }
 
 // @TODO can this be removed? legacy, short url should be created from BranchUniversalObject
+#pragma mark getShortUrl
 RCT_EXPORT_METHOD(
                   getShortUrl:(NSDictionary *)linkPropertiesMap
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -313,6 +325,7 @@ RCT_EXPORT_METHOD(
                               }];
 }
 
+#pragma mark loadRewards
 RCT_EXPORT_METHOD(
                   loadRewards:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
@@ -328,6 +341,7 @@ RCT_EXPORT_METHOD(
     }];
 }
 
+#pragma mark redeemRewards
 RCT_EXPORT_METHOD(
                   redeemRewards:(NSInteger *)amount
                   inBucket:(NSString *)bucket
@@ -355,6 +369,7 @@ RCT_EXPORT_METHOD(
     }
 }
 
+#pragma mark getCreditHistory
 RCT_EXPORT_METHOD(
                   getCreditHistory:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
@@ -369,6 +384,7 @@ RCT_EXPORT_METHOD(
     }];
 }
 
+#pragma mark createUniversalObject
 RCT_EXPORT_METHOD(
                   createUniversalObject:(NSDictionary *)universalObjectProperties
                   resolver:(RCTPromiseResolveBlock)resolve
@@ -377,9 +393,14 @@ RCT_EXPORT_METHOD(
     BranchUniversalObject *universalObject = [[BranchUniversalObject alloc] initWithMap:universalObjectProperties];
     NSString *identifier = [NSUUID UUID].UUIDString;
     self.universalObjectMap[identifier] = universalObject;
-    resolve(@{IdentFieldName: identifier});
+    NSDictionary *response = @{IdentFieldName: identifier};
+
+    // RCTLogInfo(@"Created BUO. Returning response: %@", response);
+
+    resolve(response);
 }
 
+#pragma mark releaseUniversalObject
 RCT_EXPORT_METHOD(
                   releaseUniversalObject:(NSString *)identifier
                   ) {

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -136,7 +136,7 @@ RCT_EXPORT_MODULE();
         
         RCTLogError(@"%@", error.localizedDescription);
 
-        reject(@"RNBranch::Error", errorMessage, error);
+        reject(@"RNBranch::Error::BUONotFound", errorMessage, error);
     }
     
     return universalObject;

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -4,6 +4,7 @@
 #import <React/RCTLog.h>
 #import "BranchLinkProperties+RNBranch.h"
 #import "BranchUniversalObject+RNBranch.h"
+#import "RNBranchAgingDictionary.h"
 
 static NSDictionary *initSessionWithLaunchOptionsResult;
 static NSURL *sourceUrl;
@@ -20,7 +21,7 @@ static NSInteger const RNBranchUniversalObjectNotFoundError = 1;
 
 @interface RNBranch()
 @property (nonatomic, readonly) UIViewController *currentViewController;
-@property (nonatomic) NSMutableDictionary<NSString *, BranchUniversalObject *> *universalObjectMap;
+@property (nonatomic) RNBranchAgingDictionary<NSString *, BranchUniversalObject *> *universalObjectMap;
 @end
 
 #pragma mark - RNBranch implementation
@@ -74,7 +75,7 @@ RCT_EXPORT_MODULE();
     self = [super init];
 
     if (self) {
-        _universalObjectMap = [NSMutableDictionary dictionary];
+        _universalObjectMap = [RNBranchAgingDictionary dictionaryWithTtl:3600.0];
 
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(onInitSessionFinished:) name:initSessionWithLaunchOptionsFinishedEventName object:nil];
     }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -134,8 +134,6 @@ RCT_EXPORT_MODULE();
                                                     NSLocalizedDescriptionKey: errorMessage
                                                     }];
         
-        RCTLogError(@"%@", error.localizedDescription);
-
         reject(@"RNBranch::Error::BUONotFound", errorMessage, error);
     }
     
@@ -394,8 +392,6 @@ RCT_EXPORT_METHOD(
     NSString *identifier = [NSUUID UUID].UUIDString;
     self.universalObjectMap[identifier] = universalObject;
     NSDictionary *response = @{IdentFieldName: identifier};
-
-    // RCTLogInfo(@"Created BUO. Returning response: %@", response);
 
     resolve(response);
 }

--- a/ios/RNBranch.xcodeproj/project.pbxproj
+++ b/ios/RNBranch.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		7B1D335B1E410DD200755B98 /* NSObject+RNBranch.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D33531E410DD200755B98 /* NSObject+RNBranch.m */; };
 		7B1D335C1E410DD200755B98 /* RNBranchProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B1D33541E410DD200755B98 /* RNBranchProperty.h */; };
 		7B1D335D1E410DD300755B98 /* RNBranchProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B1D33551E410DD200755B98 /* RNBranchProperty.m */; };
+		7B3B27501E707CD7003ABDF4 /* RNBranchAgingItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3B274E1E707CD7003ABDF4 /* RNBranchAgingItem.h */; };
+		7B3B27511E707CD7003ABDF4 /* RNBranchAgingItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3B274F1E707CD7003ABDF4 /* RNBranchAgingItem.m */; };
+		7B3B27541E707CF5003ABDF4 /* RNBranchAgingDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3B27521E707CF5003ABDF4 /* RNBranchAgingDictionary.h */; };
+		7B3B27551E707CF5003ABDF4 /* RNBranchAgingDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3B27531E707CF5003ABDF4 /* RNBranchAgingDictionary.m */; };
 		7B3FCB261E20626A008E38E2 /* RNBranch.h in Headers */ = {isa = PBXBuildFile; fileRef = 148030ED1CCDF9FA004ABEA4 /* RNBranch.h */; };
 		7B3FCB331E206323008E38E2 /* RNBranch.h in Copy Headers */ = {isa = PBXBuildFile; fileRef = 148030ED1CCDF9FA004ABEA4 /* RNBranch.h */; };
 		7BA33EBC1E25AD6D00C61D15 /* Branch.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BA33EBB1E25AD6D00C61D15 /* Branch.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
@@ -47,6 +51,10 @@
 		7B1D33531E410DD200755B98 /* NSObject+RNBranch.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSObject+RNBranch.m"; sourceTree = "<group>"; };
 		7B1D33541E410DD200755B98 /* RNBranchProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranchProperty.h; sourceTree = "<group>"; };
 		7B1D33551E410DD200755B98 /* RNBranchProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchProperty.m; sourceTree = "<group>"; };
+		7B3B274E1E707CD7003ABDF4 /* RNBranchAgingItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranchAgingItem.h; sourceTree = "<group>"; };
+		7B3B274F1E707CD7003ABDF4 /* RNBranchAgingItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchAgingItem.m; sourceTree = "<group>"; };
+		7B3B27521E707CF5003ABDF4 /* RNBranchAgingDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNBranchAgingDictionary.h; sourceTree = "<group>"; };
+		7B3B27531E707CF5003ABDF4 /* RNBranchAgingDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchAgingDictionary.m; sourceTree = "<group>"; };
 		7B3FCB961E20675B008E38E2 /* libBranch.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libBranch.a; path = "/Users/jdee/branch/react-native-sandbox/testbed/ios/Pods/../build/Debug-iphoneos/Branch/libBranch.a"; sourceTree = "<absolute>"; };
 		7BA33EBB1E25AD6D00C61D15 /* Branch.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Branch.framework; path = "$(PODS_CONFIGURATION_BUILD_DIR)/Branch/Branch.framework"; sourceTree = "<group>"; };
 		B3A3CC361C5B0A070016AC52 /* libreact-native-branch.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libreact-native-branch.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -85,6 +93,10 @@
 				7B1D33531E410DD200755B98 /* NSObject+RNBranch.m */,
 				148030ED1CCDF9FA004ABEA4 /* RNBranch.h */,
 				148030EE1CCDF9FA004ABEA4 /* RNBranch.m */,
+				7B3B27521E707CF5003ABDF4 /* RNBranchAgingDictionary.h */,
+				7B3B27531E707CF5003ABDF4 /* RNBranchAgingDictionary.m */,
+				7B3B274E1E707CD7003ABDF4 /* RNBranchAgingItem.h */,
+				7B3B274F1E707CD7003ABDF4 /* RNBranchAgingItem.m */,
 				7B1D33541E410DD200755B98 /* RNBranchProperty.h */,
 				7B1D33551E410DD200755B98 /* RNBranchProperty.m */,
 				B3A3CC371C5B0A070016AC52 /* Products */,
@@ -107,11 +119,13 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B3B27501E707CD7003ABDF4 /* RNBranchAgingItem.h in Headers */,
 				7B3FCB261E20626A008E38E2 /* RNBranch.h in Headers */,
 				7B1D33581E410DD200755B98 /* BranchUniversalObject+RNBranch.h in Headers */,
 				7B1D335C1E410DD200755B98 /* RNBranchProperty.h in Headers */,
 				7B1D335A1E410DD200755B98 /* NSObject+RNBranch.h in Headers */,
 				7B1D33561E410DD200755B98 /* BranchLinkProperties+RNBranch.h in Headers */,
+				7B3B27541E707CF5003ABDF4 /* RNBranchAgingDictionary.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -172,9 +186,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B3B27551E707CF5003ABDF4 /* RNBranchAgingDictionary.m in Sources */,
 				7B1D33571E410DD200755B98 /* BranchLinkProperties+RNBranch.m in Sources */,
 				7B1D335D1E410DD300755B98 /* RNBranchProperty.m in Sources */,
 				7B1D33591E410DD200755B98 /* BranchUniversalObject+RNBranch.m in Sources */,
+				7B3B27511E707CD7003ABDF4 /* RNBranchAgingItem.m in Sources */,
 				7BE575131E205B8600C936E2 /* RNBranch.m in Sources */,
 				7B1D335B1E410DD200755B98 /* NSObject+RNBranch.m in Sources */,
 			);

--- a/ios/RNBranchAgingDictionary.h
+++ b/ios/RNBranchAgingDictionary.h
@@ -12,9 +12,13 @@
 
 @property (nonatomic, readonly) NSTimeInterval ttl;
 
+#pragma mark - Object lifecycle
+
 - (instancetype)initWithTtl:(NSTimeInterval)ttl NS_DESIGNATED_INITIALIZER;
 
 + (instancetype)dictionaryWithTtl:(NSTimeInterval)ttl;
+
+#pragma mark - Methods from NSMutableDictionary
 
 - (void)setObject:(ObjectType)object forKey:(KeyType<NSCopying>)key;
 - (void)setObject:(ObjectType)object forKeyedSubscript:(KeyType<NSCopying>)key;

--- a/ios/RNBranchAgingDictionary.h
+++ b/ios/RNBranchAgingDictionary.h
@@ -1,0 +1,29 @@
+//
+//  RNBranchAgingDictionary.h
+//  RNBranch
+//
+//  Created by Jimmy Dee on 3/8/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class RNBranchAgingItem;
+
+@interface RNBranchAgingDictionary<KeyType, ObjectType> : NSObject
+
+@property (nonatomic, readonly) NSTimeInterval ttl;
+
+- (instancetype)initWithTtl:(NSTimeInterval)ttl NS_DESIGNATED_INITIALIZER;
+
++ (instancetype)dictionaryWithTtl:(NSTimeInterval)ttl;
+
+- (void)setObject:(ObjectType)object forKey:(KeyType<NSCopying>)key;
+- (void)setObject:(ObjectType)object forKeyedSubscript:(KeyType<NSCopying>)key;
+
+- (nullable ObjectType)objectForKey:(KeyType)key;
+- (nullable ObjectType)objectForKeyedSubscript:(KeyType)key;
+
+- (void)removeObjectForKey:(KeyType)key;
+
+@end

--- a/ios/RNBranchAgingDictionary.h
+++ b/ios/RNBranchAgingDictionary.h
@@ -8,8 +8,6 @@
 
 #import <Foundation/Foundation.h>
 
-@class RNBranchAgingItem;
-
 @interface RNBranchAgingDictionary<KeyType, ObjectType> : NSObject
 
 @property (nonatomic, readonly) NSTimeInterval ttl;

--- a/ios/RNBranchAgingDictionary.m
+++ b/ios/RNBranchAgingDictionary.m
@@ -6,8 +6,6 @@
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
-#import <React/RCTLog.h>
-
 #import "RNBranchAgingDictionary.h"
 #import "RNBranchAgingItem.h"
 
@@ -80,8 +78,6 @@
 - (void)ageItems
 {
     NSTimeInterval now = [NSDate date].timeIntervalSince1970;
-    NSUInteger numItems = self.dictionary.count;
-    RCTLog(@"%lu items in dictionary", (unsigned long)numItems);
 
     for (NSString *key in self.dictionary.allKeys) {
         RNBranchAgingItem *item = [self.dictionary objectForKey:key];

--- a/ios/RNBranchAgingDictionary.m
+++ b/ios/RNBranchAgingDictionary.m
@@ -65,13 +65,12 @@
 {
     [self ageItems];
 
-    RNBranchAgingItem *item = [[RNBranchAgingItem alloc] initWithItem:obj];
-    [self.dictionary setObject:item forKeyedSubscript:key];
+    self.dictionary[key] = [[RNBranchAgingItem alloc] initWithItem:obj];
 }
 
 - (id)itemForKey:(id)key
 {
-    RNBranchAgingItem *item = [self.dictionary objectForKey:key];
+    RNBranchAgingItem *item = self.dictionary[key];
     return item.item;
 }
 
@@ -79,8 +78,10 @@
 {
     NSTimeInterval now = [NSDate date].timeIntervalSince1970;
 
-    for (NSString *key in self.dictionary.allKeys) {
-        RNBranchAgingItem *item = [self.dictionary objectForKey:key];
+    NSArray<NSString *> *keys = self.dictionary.allKeys; // copy of allKeys
+
+    for (NSString *key in keys) {
+        RNBranchAgingItem *item = self.dictionary[key];
         if ((now - item.accessTime) >= self.ttl) {
             [self.dictionary removeObjectForKey:key];
         }

--- a/ios/RNBranchAgingDictionary.m
+++ b/ios/RNBranchAgingDictionary.m
@@ -32,7 +32,7 @@
     return self;
 }
 
-#pragma mark - Overrides from superclass
+#pragma mark - Methods from NSMutableDictionary
 
 - (void)setObject:(id)anObject forKey:(id<NSCopying>)aKey
 {

--- a/ios/RNBranchAgingDictionary.m
+++ b/ios/RNBranchAgingDictionary.m
@@ -1,0 +1,94 @@
+//
+//  RNBranchAgingDictionary.m
+//  RNBranch
+//
+//  Created by Jimmy Dee on 3/8/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <React/RCTLog.h>
+
+#import "RNBranchAgingDictionary.h"
+#import "RNBranchAgingItem.h"
+
+@interface RNBranchAgingDictionary()
+@property (nonatomic) NSMutableDictionary *dictionary;
+@end
+
+@implementation RNBranchAgingDictionary
+
+#pragma mark - Object lifecycle
+
++ (instancetype)dictionaryWithTtl:(NSTimeInterval)ttl
+{
+    return [[self alloc] initWithTtl:ttl];
+}
+
+- (instancetype)initWithTtl:(NSTimeInterval)ttl
+{
+    self = [super init];
+    if (self) {
+        _ttl = ttl;
+        _dictionary = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+#pragma mark - Overrides from superclass
+
+- (void)setObject:(id)anObject forKey:(id<NSCopying>)aKey
+{
+    [self insertItem:anObject forKey:aKey];
+}
+
+- (void)setObject:(id)obj forKeyedSubscript:(id<NSCopying>)key
+{
+    [self insertItem:obj forKey:key];
+}
+
+- (id)objectForKey:(id)aKey
+{
+    return [self itemForKey:aKey];
+}
+
+- (id)objectForKeyedSubscript:(id)key
+{
+    return [self itemForKey:key];
+}
+
+- (void)removeObjectForKey:(id)key
+{
+    [self.dictionary removeObjectForKey:key];
+}
+
+#pragma mark - Internal utilities
+
+- (void)insertItem:(id)obj forKey:(id<NSCopying>)key
+{
+    [self ageItems];
+
+    RNBranchAgingItem *item = [[RNBranchAgingItem alloc] initWithItem:obj];
+    [self.dictionary setObject:item forKeyedSubscript:key];
+}
+
+- (id)itemForKey:(id)key
+{
+    RNBranchAgingItem *item = [self.dictionary objectForKey:key];
+    return item.item;
+}
+
+- (void)ageItems
+{
+    NSTimeInterval now = [NSDate date].timeIntervalSince1970;
+    NSUInteger numItems = self.dictionary.count;
+    RCTLog(@"%lu items in dictionary", (unsigned long)numItems);
+
+    for (NSString *key in self.dictionary.allKeys) {
+        RNBranchAgingItem *item = [self.dictionary objectForKey:key];
+        if ((now - item.accessTime) >= self.ttl) {
+            [self.dictionary removeObjectForKey:key];
+        }
+    }
+}
+
+@end

--- a/ios/RNBranchAgingItem.h
+++ b/ios/RNBranchAgingItem.h
@@ -1,0 +1,18 @@
+//
+//  RNBranchAgingItem.h
+//  RNBranch
+//
+//  Created by Jimmy Dee on 3/8/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface RNBranchAgingItem : NSObject
+
+@property (nonatomic, readonly) id item;
+@property (nonatomic, readonly) NSTimeInterval accessTime;
+
+- (instancetype) initWithItem:(id)item NS_DESIGNATED_INITIALIZER;
+
+@end

--- a/ios/RNBranchAgingItem.m
+++ b/ios/RNBranchAgingItem.m
@@ -1,0 +1,30 @@
+//
+//  RNBranchAgingItem.m
+//  RNBranch
+//
+//  Created by Jimmy Dee on 3/8/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import "RNBranchAgingItem.h"
+
+@implementation RNBranchAgingItem {
+    id _item;
+}
+
+- (instancetype)initWithItem:(id)item
+{
+    self = [super init];
+    if (self) {
+        _item = item;
+        _accessTime = [NSDate date].timeIntervalSince1970;
+    }
+    return self;
+}
+- (id)item
+{
+    _accessTime = [NSDate date].timeIntervalSince1970;
+    return _item;
+}
+
+@end

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -46,16 +46,13 @@ export default async function createBranchUniversalObject(identifier, options = 
 
     tryFunction(func, ident, ...args) {
       return func(ident, ...args).catch((error) => {
-        console.error("Error code = " + error.code)
         if (error.code != "RNBranch::Error::BUONotFound") {
           throw error
-          console.log("rethrew error")
         }
 
         return RNBranch.createUniversalObject(branchUniversalObject)
       })
       .then((response) => {
-        console.info("Created new BUO with ident " + response.ident)
         this.ident = response.ident
         return func(response.ident, ...args)
       })

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -28,24 +28,24 @@ export default async function createBranchUniversalObject(identifier, options = 
         ...linkProperties,
       }
 
-      return this.tryFunction(RNBranch.showShareSheet, this.ident, shareOptions, linkProperties, controlParams)
+      return this.tryFunction(RNBranch.showShareSheet, shareOptions, linkProperties, controlParams)
     },
     registerView() {
-      return this.tryFunction(RNBranch.registerView, this.ident)
+      return this.tryFunction(RNBranch.registerView)
     },
     generateShortUrl(linkProperties = {}, controlParams = {}) {
-      return this.tryFunction(RNBranch.generateShortUrl, this.ident, linkProperties, controlParams)
+      return this.tryFunction(RNBranch.generateShortUrl, linkProperties, controlParams)
     },
     listOnSpotlight() {
       if (Platform.OS !== 'ios') return Promise.resolve()
-      return this.tryFunction(RNBranch.listOnSpotlight, this.ident)
+      return this.tryFunction(RNBranch.listOnSpotlight)
     },
     release() {
       RNBranch.releaseUniversalObject(this.ident)
     },
 
-    tryFunction(func, ident, ...args) {
-      return func(ident, ...args).catch((error) => {
+    tryFunction(func, ...args) {
+      return func(this.ident, ...args).catch((error) => {
         if (error.code != "RNBranch::Error::BUONotFound") {
           throw error
         }

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -11,7 +11,7 @@ export default async function createBranchUniversalObject(identifier, options = 
     ...options
   }
 
-  const { ident } = await RNBranch.createUniversalObject(branchUniversalObject)
+  let { ident } = await RNBranch.createUniversalObject(branchUniversalObject)
 
   return {
     ident: ident,

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -14,6 +14,7 @@ export default async function createBranchUniversalObject(identifier, options = 
   const { ident } = await RNBranch.createUniversalObject(branchUniversalObject)
 
   return {
+    ident: ident,
     showShareSheet(shareOptions = {}, linkProperties = {}, controlParams = {}) {
       shareOptions = {
         title: options.title || '',
@@ -27,20 +28,32 @@ export default async function createBranchUniversalObject(identifier, options = 
         ...linkProperties,
       }
 
-      return RNBranch.showShareSheet(ident, shareOptions, linkProperties, controlParams)
+      return RNBranch.showShareSheet(this.ident, shareOptions, linkProperties, controlParams)
     },
     registerView() {
-      return RNBranch.registerView(ident)
+      return RNBranch.registerView(this.ident)
     },
-    generateShortUrl(linkProperties = {}, controlParams = {}) {
-      return RNBranch.generateShortUrl(ident, linkProperties, controlParams)
+    async generateShortUrl(linkProperties = {}, controlParams = {}) {
+      // try {
+      return RNBranch.generateShortUrl(this.ident, linkProperties, controlParams)
+      .catch (async (error) => {
+        console.error("Error code = " + error.code)
+        if (error.code != "RNBranch::Error::BUONotFound") {
+          throw error
+        }
+
+        let { newIdent } = await RNBranch.createUniversalObject(branchUniversalObject)
+        this.ident = newIdent
+        console.info("Created new BUO with ident " + newIdent)
+        return RNBranch.generateShortUrl(newIdent, linkProperties, controlParams)
+      })
     },
     listOnSpotlight() {
       if (Platform.OS !== 'ios') return Promise.resolve()
-      return RNBranch.listOnSpotlight(ident)
+      return RNBranch.listOnSpotlight(this.ident)
     },
     release() {
-      RNBranch.releaseUniversalObject(ident)
+      RNBranch.releaseUniversalObject(this.ident)
     }
   }
 }

--- a/testbed/testbed_cocoapods/android/app/app.iml
+++ b/testbed/testbed_cocoapods/android/app/app.iml
@@ -80,6 +80,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
@@ -139,24 +140,5 @@
     <orderEntry type="library" exported="" name="appcompat-v7-23.0.1" level="project" />
     <orderEntry type="library" exported="" name="fbcore-0.11.0" level="project" />
     <orderEntry type="module" module-name="react-native-branch" exported="" />
-    <orderEntry type="library" exported="" name="okhttp-ws-2.5.0" level="project" />
-    <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
-    <orderEntry type="library" exported="" name="stetho-okhttp-1.2.0" level="project" />
-    <orderEntry type="library" exported="" name="okhttp-2.5.0" level="project" />
-    <orderEntry type="library" exported="" name="answers-shim-0.0.6" level="project" />
-    <orderEntry type="library" exported="" name="stetho-1.2.0" level="project" />
-    <orderEntry type="library" exported="" name="jackson-core-2.2.3" level="project" />
-    <orderEntry type="library" exported="" name="fbcore-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="commons-cli-1.2" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-23.0.1" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="fresco-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-okhttp-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="library-2.5.9" level="project" />
-    <orderEntry type="library" exported="" name="bolts-android-1.1.4" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-23.0.1" level="project" />
-    <orderEntry type="library" exported="" name="drawee-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="react-native-0.20.1" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
   </component>
 </module>

--- a/testbed/testbed_cocoapods/android/app/app.iml
+++ b/testbed/testbed_cocoapods/android/app/app.iml
@@ -9,7 +9,6 @@
     <facet type="android" name="Android">
       <configuration>
         <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
         <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
         <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
         <afterSyncTasks>
@@ -47,7 +46,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/debug/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/shaders" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/res" type="java-test-resource" />
@@ -55,7 +53,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/testDebug/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/testDebug/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/res" type="java-resource" />
@@ -63,28 +60,26 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/assets" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/aidl" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
@@ -99,11 +94,22 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.soloader/soloader/0.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/org.webkit/android-jsc/r174650/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-resources" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/split-apk" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
@@ -146,10 +152,10 @@
     <orderEntry type="library" exported="" name="imagepipeline-0.8.1" level="project" />
     <orderEntry type="library" exported="" name="fresco-0.8.1" level="project" />
     <orderEntry type="library" exported="" name="imagepipeline-okhttp-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="library-2.5.9" level="project" />
     <orderEntry type="library" exported="" name="bolts-android-1.1.4" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.0.1" level="project" />
     <orderEntry type="library" exported="" name="drawee-0.8.1" level="project" />
-    <orderEntry type="library" exported="" name="library-2.5.8" level="project" />
     <orderEntry type="library" exported="" name="react-native-0.20.1" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
   </component>

--- a/testbed/testbed_cocoapods/android/app/app.iml
+++ b/testbed/testbed_cocoapods/android/app/app.iml
@@ -80,20 +80,6 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.0.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fbui.textlayoutbuilder/textlayoutbuilder/1.0.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/drawee/0.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/fbcore/0.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/fresco/0.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/imagepipeline-base/0.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/imagepipeline-okhttp3/0.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.fresco/imagepipeline/0.11.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.react/react-native/0.41.2/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.facebook.soloader/soloader/0.1.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/org.webkit/android-jsc/r174650/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
@@ -117,28 +103,47 @@
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="okio-1.9.0" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-0.11.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="library-2.4.0" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-base-0.11.0" level="project" />
     <orderEntry type="library" exported="" name="textlayoutbuilder-1.0.0" level="project" />
     <orderEntry type="library" exported="" name="fresco-0.11.0" level="project" />
     <orderEntry type="library" exported="" name="drawee-0.11.0" level="project" />
-    <orderEntry type="library" exported="" name="soloader-0.1.0" level="project" />
-    <orderEntry type="library" exported="" name="javax.inject-1" level="project" />
     <orderEntry type="library" exported="" name="jsr305-3.0.0" level="project" />
     <orderEntry type="library" exported="" name="bolts-tasks-1.4.0" level="project" />
     <orderEntry type="library" exported="" name="okhttp-urlconnection-3.4.1" level="project" />
-    <orderEntry type="library" exported="" name="okhttp-ws-3.4.1" level="project" />
     <orderEntry type="library" exported="" name="android-jsc-r174650" level="project" />
-    <orderEntry type="library" exported="" name="okhttp-3.4.1" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.4.0" level="project" />
     <orderEntry type="library" exported="" name="staticlayout-proxy-1.0" level="project" />
     <orderEntry type="library" exported="" name="recyclerview-v7-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="imagepipeline-okhttp3-0.11.0" level="project" />
-    <orderEntry type="library" exported="" name="react-native-0.41.2" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-23.0.1" level="project" />
     <orderEntry type="library" exported="" name="fbcore-0.11.0" level="project" />
+    <orderEntry type="library" exported="" name="imagepipeline-0.11.0" level="project" />
+    <orderEntry type="library" exported="" name="library-2.4.0" level="project" />
+    <orderEntry type="library" exported="" name="imagepipeline-base-0.11.0" level="project" />
+    <orderEntry type="library" exported="" name="soloader-0.1.0" level="project" />
+    <orderEntry type="library" exported="" name="answers-shim-0.0.6" level="project" />
+    <orderEntry type="library" exported="" name="javax.inject-1" level="project" />
+    <orderEntry type="library" exported="" name="okhttp-ws-3.4.1" level="project" />
+    <orderEntry type="library" exported="" name="okhttp-3.4.1" level="project" />
+    <orderEntry type="library" exported="" name="library-2.5.9" level="project" />
+    <orderEntry type="library" exported="" name="imagepipeline-okhttp3-0.11.0" level="project" />
+    <orderEntry type="library" exported="" name="react-native-0.41.2" level="project" />
     <orderEntry type="module" module-name="react-native-branch" exported="" />
+    <orderEntry type="library" exported="" name="okhttp-ws-2.5.0" level="project" />
+    <orderEntry type="library" exported="" name="okio-1.6.0" level="project" />
+    <orderEntry type="library" exported="" name="stetho-okhttp-1.2.0" level="project" />
+    <orderEntry type="library" exported="" name="okhttp-2.5.0" level="project" />
+    <orderEntry type="library" exported="" name="stetho-1.2.0" level="project" />
+    <orderEntry type="library" exported="" name="jackson-core-2.2.3" level="project" />
+    <orderEntry type="library" exported="" name="fbcore-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="commons-cli-1.2" level="project" />
+    <orderEntry type="library" exported="" name="recyclerview-v7-23.0.1" level="project" />
+    <orderEntry type="library" exported="" name="imagepipeline-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="fresco-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="imagepipeline-okhttp-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="bolts-android-1.1.4" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-23.0.1" level="project" />
+    <orderEntry type="library" exported="" name="drawee-0.8.1" level="project" />
+    <orderEntry type="library" exported="" name="react-native-0.20.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.0.1" level="project" />
   </component>
 </module>

--- a/testbed/testbed_cocoapods/android/app/build.gradle
+++ b/testbed/testbed_cocoapods/android/app/build.gradle
@@ -78,7 +78,7 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         applicationId "com.testbed_cocoapods"

--- a/testbed/testbed_cocoapods/android/build.gradle
+++ b/testbed/testbed_cocoapods/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/testbed/testbed_cocoapods/android/gradle/wrapper/gradle-wrapper.properties
+++ b/testbed/testbed_cocoapods/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Jan 12 10:01:06 PST 2017
+#Thu Mar 09 11:19:17 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/testbed/testbed_cocoapods/android/testbed_cocoapods.iml
+++ b/testbed/testbed_cocoapods/android/testbed_cocoapods.iml
@@ -13,7 +13,7 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
-    <orderEntry type="inheritedJdk" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/testbed/testbed_cocoapods/src/BranchMethods.js
+++ b/testbed/testbed_cocoapods/src/BranchMethods.js
@@ -24,6 +24,7 @@ class BranchMethods extends Component {
       this.buo = result
       console.log('createBranchUniversalObject', result)
       this.addResult('success', 'createBranchUniversalObject', result)
+      this.buo.release()
     } catch (err) {
       console.log('createBranchUniversalObject err', err.toString())
       this.addResult('error', 'createBranchUniversalObject', err.toString())

--- a/testbed/testbed_cocoapods/src/BranchMethods.js
+++ b/testbed/testbed_cocoapods/src/BranchMethods.js
@@ -24,7 +24,6 @@ class BranchMethods extends Component {
       this.buo = result
       console.log('createBranchUniversalObject', result)
       this.addResult('success', 'createBranchUniversalObject', result)
-      this.buo.release()
     } catch (err) {
       console.log('createBranchUniversalObject err', err.toString())
       this.addResult('error', 'createBranchUniversalObject', err.toString())


### PR DESCRIPTION
This is a remedy to the growth issue discussed in a [recent pull request](https://github.com/BranchMetrics/react-native-branch-deep-linking/pull/117).

Introduced io.branch.rnbranch.AgingHash (Android) and RNBranchAgingDictionary (iOS). These containers require a TTL at initialization and will purge old entries on insertion. Items that have not been accessed within the TTL are removed from the container whenever a new item is inserted. This prevents long-term, unlimited memory growth.

The original problem is that the native layers never know if the corresponding JS object still exists, so it's possible to make a call after an expired Branch Universal Object has been removed from the native cache, if the JS object is still around. Then the specified ident is not found in the cache, and an error has to be generated. In this case an error is returned to JS with the code `RNBranch::Error::BUONotFound`. The JS object still has the parameters used to create the BUO. When it receives this error code, it creates a new BUO on the spot by passing the parameters back to `RNBranch.createUniversalObject`, receives a new ident, updates the ident on the JS object and then calls the method on the new native BUO. The new BUO is inserted into the native cache with a new access time and will be retained for the TTL or until `release()` is called from JS.

This solution has the following virtues:

- The JS BUO wraps a native instance, guaranteeing a one-to-one relationship as long as the BUO is cached.
- The potential memory growth is limited and probably not a significant issue in a well-behaved app to begin with.
- The optional `release()` method is provided for the JS app to do proper clean-up if memory growth is a concern.
- If `release()` is not called on the JS BUO, the native object will not be cached beyond the TTL if further BUOs are created.
- If a cached BUO expires, JS operations will complete normally, at the expense of continuity between native instances.

It also has a couple of potential points of failure. If a call is made after a BUO expires from the native cache, a new instance of the object has to be created, which is the problem that the original change was intended to fix. However, this should happen much less often now. For example, the TTL in the current code base is one hour. To provoke this condition, the app would have to do the following:

- Create a BUO in JS
- Live for more than an hour, probably in the background
- Create a new BUO in JS after the TTL expires for the first BUO
- Use the first BUO again (call a method on the JS BUO)

The most likely scenario here would be something like opening a modal an hour later that creates a new BUO, then dismissing it and calling something like `registerView()` again. In this case, creating a new BUO instance for the same item should not be an issue.

This scenario can also arise if an app incorrectly calls a method on a JS BUO after calling `release()`. Now that automated GC of a sort is available, the `release()` method could be removed. 

There is little defense against certain extreme pathological cases, such as an app creating thousands of temporary BUOs in a loop without calling `release()` each time. In a normal, well-behaved app, there should never be more than a handful of cached BUOs at any given time, and at any rate, the SDK should never fail given that the native BUO can be reconstructed as necessary.