### PR TITLE
[OS-19][OS-24] Add native notification for iOS and finish testbed_native_ios

### DIFF
--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -1,6 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 
+extern NSString * const RNBranchLinkOpenedNotification;
+extern NSString * const RNBranchLinkOpenedNotificationErrorKey;
+extern NSString * const RNBranchLinkOpenedNotificationParamsKey;
+extern NSString * const RNBranchLinkOpenedNotificationUriKey;
+
 @interface RNBranch : NSObject <RCTBridgeModule>
 
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable;

--- a/testbed/testbed_native_ios/src/BranchMethods.js
+++ b/testbed/testbed_native_ios/src/BranchMethods.js
@@ -3,7 +3,7 @@ import { ScrollView, StyleSheet, Text, View } from 'react-native'
 
 import Button from './Button'
 
-import branch from 'react-native-branch'
+import branch, { RegisterViewEvent } from 'react-native-branch'
 
 const defaultBUO = {
   title: 'wallo'
@@ -17,9 +17,15 @@ class BranchMethods extends Component {
     results: [],
   }
 
+  componentWillUnmount() {
+    if (!this.buo) return
+    this.buo.release()
+  }
+
   createBranchUniversalObject = async () => {
     try {
       let result = await branch.createBranchUniversalObject('abc', defaultBUO)
+      if (this.buo) this.buo.release()
       this.buo = result
       console.log('createBranchUniversalObject', result)
       this.addResult('success', 'createBranchUniversalObject', result)
@@ -38,18 +44,6 @@ class BranchMethods extends Component {
     } catch (err) {
       console.log('generateShortUrl err', err)
       this.addResult('error', 'generateShortUrl', err.toString())
-    }
-  }
-
-  registerView = async () => {
-    if (!this.buo) await this.createBranchUniversalObject()
-    try {
-      let result = await this.buo.registerView()
-      console.log('registerView', result)
-      this.addResult('success', 'registerView', result)
-    } catch (err) {
-      console.log('registerView err', err.toString())
-      this.addResult('error', 'registerView', err.toString())
     }
   }
 
@@ -110,6 +104,18 @@ class BranchMethods extends Component {
     }
   }
 
+  userCompletedAction = async() => {
+    if (!this.buo) await this.createBranchUniversalObject()
+    try {
+      let result = await this.buo.userCompletedAction(RegisterViewEvent)
+      console.log('userCompletedAction', result)
+      this.addResult('success', 'userCompletedAction', result)
+    } catch (err) {
+      console.log('userCompletedAction err', err.toString())
+      this.addResult('error', 'userCompletedAction', err.toString())
+    }
+  }
+
   addResult(type, slug, payload) {
     let result = { type, slug, payload }
     this.setState({
@@ -137,8 +143,8 @@ class BranchMethods extends Component {
         <Text style={styles.header}>METHODS</Text>
         <ScrollView style={styles.buttonsContainer}>
           <Button onPress={this.createBranchUniversalObject}>createBranchUniversalObject</Button>
+          <Button onPress={this.userCompletedAction}>userCompletedAction</Button>
           <Button onPress={this.generateShortUrl}>generateShortUrl</Button>
-          <Button onPress={this.registerView}>registerView</Button>
           <Button onPress={this.listOnSpotlight}>listOnSpotlight</Button>
           <Button onPress={this.showShareSheet}>showShareSheet</Button>
           <Button onPress={this.redeemRewards.bind(this, '')}>redeemRewards</Button>

--- a/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/project.pbxproj
+++ b/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7B6377631E831BF6009227D1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7B6377611E831BF6009227D1 /* Main.storyboard */; };
 		7B6377651E831BF6009227D1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7B6377641E831BF6009227D1 /* Assets.xcassets */; };
 		7B6377681E831BF6009227D1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7B6377661E831BF6009227D1 /* LaunchScreen.storyboard */; };
+		7B6377C91E834150009227D1 /* main.jsbundle in Resources */ = {isa = PBXBuildFile; fileRef = 7B6377C81E834150009227D1 /* main.jsbundle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -27,6 +28,8 @@
 		7B6377641E831BF6009227D1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7B6377671E831BF6009227D1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7B6377691E831BF6009227D1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7B6377961E833F57009227D1 /* testbed_native_ios.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = testbed_native_ios.entitlements; sourceTree = "<group>"; };
+		7B6377C81E834150009227D1 /* main.jsbundle */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = main.jsbundle; sourceTree = "<group>"; };
 		8E214B899E1861D89268F2CE /* Pods-testbed_native_ios.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testbed_native_ios.debug.xcconfig"; path = "Pods/Target Support Files/Pods-testbed_native_ios/Pods-testbed_native_ios.debug.xcconfig"; sourceTree = "<group>"; };
 		AD34805037249BCBEA51DB6A /* libPods-testbed_native_ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-testbed_native_ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F7AE53FD155ABDCFC1404DD7 /* Pods-testbed_native_ios.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-testbed_native_ios.release.xcconfig"; path = "Pods/Target Support Files/Pods-testbed_native_ios/Pods-testbed_native_ios.release.xcconfig"; sourceTree = "<group>"; };
@@ -82,6 +85,8 @@
 		7B6377571E831BF6009227D1 /* testbed_native_ios */ = {
 			isa = PBXGroup;
 			children = (
+				7B6377C81E834150009227D1 /* main.jsbundle */,
+				7B6377961E833F57009227D1 /* testbed_native_ios.entitlements */,
 				7B63775B1E831BF6009227D1 /* AppDelegate.h */,
 				7B63775C1E831BF6009227D1 /* AppDelegate.m */,
 				7B63775E1E831BF6009227D1 /* ViewController.h */,
@@ -116,6 +121,7 @@
 				7B6377531E831BF6009227D1 /* Resources */,
 				432D7FE72F818BEEA0AF688F /* [CP] Embed Pods Frameworks */,
 				6EE8306372A9EE4CAC94AD78 /* [CP] Copy Pods Resources */,
+				7B6377C71E834105009227D1 /* Bundle React Native code and images */,
 			);
 			buildRules = (
 			);
@@ -137,7 +143,13 @@
 				TargetAttributes = {
 					7B6377541E831BF6009227D1 = {
 						CreatedOnToolsVersion = 8.2.1;
+						DevelopmentTeam = RAARD2VX57;
 						ProvisioningStyle = Automatic;
+						SystemCapabilities = {
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
+						};
 					};
 				};
 			};
@@ -167,6 +179,7 @@
 				7B6377681E831BF6009227D1 /* LaunchScreen.storyboard in Resources */,
 				7B6377651E831BF6009227D1 /* Assets.xcassets in Resources */,
 				7B6377631E831BF6009227D1 /* Main.storyboard in Resources */,
+				7B6377C91E834150009227D1 /* main.jsbundle in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -217,6 +230,20 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-testbed_native_ios/Pods-testbed_native_ios-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		7B6377C71E834105009227D1 /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "export NODE_BINARY=node\nnode_modules/react-native/packager/react-native-xcode.sh";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -348,12 +375,14 @@
 			baseConfigurationReference = 8E214B899E1861D89268F2CE /* Pods-testbed_native_ios.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = testbed_native_ios/testbed_native_ios.entitlements;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphoneos*]" = disable;
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = RAARD2VX57;
 				INFOPLIST_FILE = testbed_native_ios/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.testbed-native-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "info.dubsar.TestBed-ReactNative";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -363,10 +392,12 @@
 			baseConfigurationReference = F7AE53FD155ABDCFC1404DD7 /* Pods-testbed_native_ios.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = testbed_native_ios/testbed_native_ios.entitlements;
 				DEBUG_ACTIVITY_MODE = "";
+				DEVELOPMENT_TEAM = RAARD2VX57;
 				INFOPLIST_FILE = testbed_native_ios/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.testbed-native-ios";
+				PRODUCT_BUNDLE_IDENTIFIER = "info.dubsar.TestBed-ReactNative";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/project.pbxproj
+++ b/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/project.pbxproj
@@ -348,6 +348,9 @@
 			baseConfigurationReference = 8E214B899E1861D89268F2CE /* Pods-testbed_native_ios.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEBUG_ACTIVITY_MODE = "";
+				"DEBUG_ACTIVITY_MODE[sdk=iphoneos*]" = disable;
+				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
 				INFOPLIST_FILE = testbed_native_ios/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.testbed-native-ios";
@@ -360,6 +363,7 @@
 			baseConfigurationReference = F7AE53FD155ABDCFC1404DD7 /* Pods-testbed_native_ios.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEBUG_ACTIVITY_MODE = "";
 				INFOPLIST_FILE = testbed_native_ios/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.testbed-native-ios";

--- a/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/project.pbxproj
+++ b/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/project.pbxproj
@@ -143,7 +143,6 @@
 				TargetAttributes = {
 					7B6377541E831BF6009227D1 = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = RAARD2VX57;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
 							com.apple.SafariKeychain = {
@@ -379,10 +378,10 @@
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphoneos*]" = disable;
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
-				DEVELOPMENT_TEAM = RAARD2VX57;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = testbed_native_ios/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "info.dubsar.TestBed-ReactNative";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.testbed-native-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -394,10 +393,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = testbed_native_ios/testbed_native_ios.entitlements;
 				DEBUG_ACTIVITY_MODE = "";
-				DEVELOPMENT_TEAM = RAARD2VX57;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = testbed_native_ios/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = "info.dubsar.TestBed-ReactNative";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.testbed-native-ios";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/xcshareddata/xcschemes/testbed_native_ios.xcscheme
+++ b/testbed/testbed_native_ios/testbed_native_ios.xcodeproj/xcshareddata/xcschemes/testbed_native_ios.xcscheme
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B6377541E831BF6009227D1"
+               BuildableName = "testbed_native_ios.app"
+               BlueprintName = "testbed_native_ios"
+               ReferencedContainer = "container:testbed_native_ios.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B6377541E831BF6009227D1"
+            BuildableName = "testbed_native_ios.app"
+            BlueprintName = "testbed_native_ios"
+            ReferencedContainer = "container:testbed_native_ios.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B6377541E831BF6009227D1"
+            BuildableName = "testbed_native_ios.app"
+            BlueprintName = "testbed_native_ios"
+            ReferencedContainer = "container:testbed_native_ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "OS_ACTIVITY_MODE"
+            value = "${DEBUG_ACTIVITY_MODE}"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B6377541E831BF6009227D1"
+            BuildableName = "testbed_native_ios.app"
+            BlueprintName = "testbed_native_ios"
+            ReferencedContainer = "container:testbed_native_ios.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/testbed/testbed_native_ios/testbed_native_ios/AppDelegate.m
+++ b/testbed/testbed_native_ios/testbed_native_ios/AppDelegate.m
@@ -15,8 +15,8 @@
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
 {
-    [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(linkOpened:) name:RNBranchLinkOpenedNotification object:nil];
+    [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
     return YES;
 }
 

--- a/testbed/testbed_native_ios/testbed_native_ios/AppDelegate.m
+++ b/testbed/testbed_native_ios/testbed_native_ios/AppDelegate.m
@@ -15,6 +15,7 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(nullable NSDictionary *)launchOptions
 {
     [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(linkOpened:) name:RNBranchLinkOpenedNotification object:nil];
     return YES;
 }
 
@@ -27,6 +28,24 @@
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler {
     return [RNBranch continueUserActivity:userActivity];
+}
+
+- (void)linkOpened:(NSNotification *)notification
+{
+    NSString *error = notification.userInfo[RNBranchLinkOpenedNotificationErrorKey];
+    NSString *params = notification.userInfo[RNBranchLinkOpenedNotificationParamsKey];
+    NSString *uri = notification.userInfo[RNBranchLinkOpenedNotificationUriKey];
+
+    NSLog(@"Received %@", notification.name);
+
+    if (error) {
+        NSLog(@"Error opening Branch link: %@", error);
+        return;
+    }
+
+    NSLog(@"uri: %@, params: %@", uri, params);
+
+    // Now route to the appropriate view
 }
 
 @end

--- a/testbed/testbed_native_ios/testbed_native_ios/AppDelegate.m
+++ b/testbed/testbed_native_ios/testbed_native_ios/AppDelegate.m
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
+#import <React/RCTLog.h>
 #import <react-native-branch/RNBranch.h>
 
 #import "AppDelegate.h"
@@ -32,18 +33,18 @@
 
 - (void)linkOpened:(NSNotification *)notification
 {
-    NSString *error = notification.userInfo[RNBranchLinkOpenedNotificationErrorKey];
-    NSString *params = notification.userInfo[RNBranchLinkOpenedNotificationParamsKey];
-    NSString *uri = notification.userInfo[RNBranchLinkOpenedNotificationUriKey];
+    NSError *error = notification.userInfo[RNBranchLinkOpenedNotificationErrorKey];
+    NSDictionary *params = notification.userInfo[RNBranchLinkOpenedNotificationParamsKey];
+    NSURL *uri = notification.userInfo[RNBranchLinkOpenedNotificationUriKey];
 
-    NSLog(@"Received %@", notification.name);
+    RCTLog(@"Received %@", notification.name);
 
     if (error) {
-        NSLog(@"Error opening Branch link: %@", error);
+        RCTLogError(@"Error opening Branch link: %@", error.localizedDescription);
         return;
     }
 
-    NSLog(@"uri: %@, params: %@", uri, params);
+    RCTLog(@"uri: %@, params: %@", uri, params);
 
     // Now route to the appropriate view
 }

--- a/testbed/testbed_native_ios/testbed_native_ios/Info.plist
+++ b/testbed/testbed_native_ios/testbed_native_ios/Info.plist
@@ -20,6 +20,17 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>localhost</key>
+			<dict>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,17 +52,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-    <key>NSAppTransportSecurity</key>
-    <dict>
-        <key>NSExceptionDomains</key>
-        <dict>
-            <key>localhost</key>
-            <dict>
-                <key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
-                <true/>
-            </dict>
-        </dict>
-    </dict>	<key>branch_key</key>
+	<key>branch_key</key>
 	<string>key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv</string>
 </dict>
 </plist>

--- a/testbed/testbed_native_ios/testbed_native_ios/ViewController.m
+++ b/testbed/testbed_native_ios/testbed_native_ios/ViewController.m
@@ -16,7 +16,11 @@
 {
     [super viewDidLoad];
 
+    // from dev server (simulator)
     NSURL *jsCodeLocation = [NSURL URLWithString:@"http://localhost:8081/index.ios.bundle?platform=ios"];
+
+    // from app bundle (device)
+    // NSURL *jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
     
     RCTRootView *rootView =
     [[RCTRootView alloc] initWithBundleURL : jsCodeLocation

--- a/testbed/testbed_native_ios/testbed_native_ios/testbed_native_ios.entitlements
+++ b/testbed/testbed_native_ios/testbed_native_ios/testbed_native_ios.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array/>
+</dict>
+</plist>

--- a/testbed/testbed_simple/src/BranchMethods.js
+++ b/testbed/testbed_simple/src/BranchMethods.js
@@ -3,7 +3,7 @@ import { ScrollView, StyleSheet, Text, View } from 'react-native'
 
 import Button from './Button'
 
-import branch from 'react-native-branch'
+import branch, { RegisterViewEvent } from 'react-native-branch'
 
 const defaultBUO = {
   title: 'wallo'
@@ -17,9 +17,15 @@ class BranchMethods extends Component {
     results: [],
   }
 
+  componentWillUnmount() {
+    if (!this.buo) return
+    this.buo.release()
+  }
+
   createBranchUniversalObject = async () => {
     try {
       let result = await branch.createBranchUniversalObject('abc', defaultBUO)
+      if (this.buo) this.buo.release()
       this.buo = result
       console.log('createBranchUniversalObject', result)
       this.addResult('success', 'createBranchUniversalObject', result)
@@ -38,18 +44,6 @@ class BranchMethods extends Component {
     } catch (err) {
       console.log('generateShortUrl err', err)
       this.addResult('error', 'generateShortUrl', err.toString())
-    }
-  }
-
-  registerView = async () => {
-    if (!this.buo) await this.createBranchUniversalObject()
-    try {
-      let result = await this.buo.registerView()
-      console.log('registerView', result)
-      this.addResult('success', 'registerView', result)
-    } catch (err) {
-      console.log('registerView err', err.toString())
-      this.addResult('error', 'registerView', err.toString())
     }
   }
 
@@ -110,6 +104,18 @@ class BranchMethods extends Component {
     }
   }
 
+  userCompletedAction = async() => {
+    if (!this.buo) await this.createBranchUniversalObject()
+    try {
+      let result = await this.buo.userCompletedAction(RegisterViewEvent)
+      console.log('userCompletedAction', result)
+      this.addResult('success', 'userCompletedAction', result)
+    } catch (err) {
+      console.log('userCompletedAction err', err.toString())
+      this.addResult('error', 'userCompletedAction', err.toString())
+    }
+  }
+
   addResult(type, slug, payload) {
     let result = { type, slug, payload }
     this.setState({
@@ -137,8 +143,8 @@ class BranchMethods extends Component {
         <Text style={styles.header}>METHODS</Text>
         <ScrollView style={styles.buttonsContainer}>
           <Button onPress={this.createBranchUniversalObject}>createBranchUniversalObject</Button>
+          <Button onPress={this.userCompletedAction}>userCompletedAction</Button>
           <Button onPress={this.generateShortUrl}>generateShortUrl</Button>
-          <Button onPress={this.registerView}>registerView</Button>
           <Button onPress={this.listOnSpotlight}>listOnSpotlight</Button>
           <Button onPress={this.showShareSheet}>showShareSheet</Button>
           <Button onPress={this.redeemRewards.bind(this, '')}>redeemRewards</Button>


### PR DESCRIPTION
Added `RNBranchLinkOpenedNotification`, generated each time the callback to `[Branch initSessionWithLaunchOptions:isReferrable:andRegisterDeepLinkHandler:]` is invoked. In particular, this allows a native app using the Branch iOS SDK to include a RN component with the react-native-branch module and still route links in the native code and also get callbacks in `branch.subscribe` in the JS app. This is illustrated in changes to the testbed_native_ios app.
