### PR TITLE
Update old testbeds

### DIFF
--- a/testbed/README.md
+++ b/testbed/README.md
@@ -1,13 +1,28 @@
 # testbed applications
 
-There are two working examples in this directory:
+There are several working examples in this directory:
+
+See each app for further details, including build instructions.
+
+## 1.1 (production)
+
+These two apps illustrate integrating the production
+SDK release. They differ only by how the iOS native SDK
+is integrated, using Carthage or CocoaPods.
+
+### [testbed_carthage](./testbed_carthage)
+
+### [testbed_cocoapods](./testbed_cocoapods)
+
+## 2.0 (beta)
+
+These apps illustrate integrating the 2.0 beta release,
+without need for Carthage, CocoaPods or manual installation.
 
 ### [testbed_simple](./testbed_simple)
 
-This app illustrates the simplest means of integrating react-native-branch into a React Native app.
+This app illustrates the simplest means of integrating react-native-branch into a React Native app, using `react-native link`.
 
 ### [testbed_native_ios](./testbed_native_ios)
 
-This app illustrates how to integrate the react-native-branch SDK into a React Native component within an existing native iOS app.
-
-See each app for further details, including build instructions.
+This app illustrates how to integrate the react-native-branch SDK into a React Native component within an existing native iOS app using the React, react-native-branch and Branch-SDK pods from node_modules.

--- a/testbed/testbed_carthage/README.md
+++ b/testbed/testbed_carthage/README.md
@@ -1,0 +1,7 @@
+# testbed_carthage
+
+This app was built with react-native-branch@1.1.1 using Carthage to integrate the iOS SDK.
+
+## Building
+
+Just run `npm install` or `yarn` to install Node dependencies in node_modules. There is no need to install or run Carthage. The native dependencies are checked into the repo.

--- a/testbed/testbed_carthage/package.json
+++ b/testbed/testbed_carthage/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "~15.4.0-rc.4",
     "react-native": "^0.42.0",
-    "react-native-branch": "file:../.."
+    "react-native-branch": "^1.1.1"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/testbed/testbed_carthage/yarn.lock
+++ b/testbed/testbed_carthage/yarn.lock
@@ -2918,8 +2918,9 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-"react-native-branch@file:../..":
-  version "1.0.6"
+react-native-branch@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-1.1.1.tgz#6c330be833eca06b50034afb01dd6a4f1c8b595b"
 
 react-native@^0.42.0:
   version "0.42.0"

--- a/testbed/testbed_cocoapods/README.md
+++ b/testbed/testbed_cocoapods/README.md
@@ -1,28 +1,7 @@
-# testbed sample app
+# testbed_cocoapods
 
-## Building for iOS
+This app was built with react-native-branch@1.1.1 using CocoaPods to integrate the iOS SDK.
 
-Install dependencies from NPM using:
+## Building
 
-```bash
-npm install
-```
-
-or
-
-```bash
-yarn
-```
-
-Then simply build and run the Xcode project or use
-
-```bash
-react-native run-ios
-```
-
-There is no need to install the Branch SDK via `pod install` or
-another method. It is included in the ios/Pods subdirectory.
-
-## Building for Android
-
-*Work in progress*
+Just run `npm install` or `yarn` to install Node dependencies in node_modules. There is no need to install or run CocoaPods. The native dependencies are checked into the repo.

--- a/testbed/testbed_cocoapods/package.json
+++ b/testbed/testbed_cocoapods/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "react": "~15.4.0-rc.4",
     "react-native": "^0.42.0",
-    "react-native-branch": "file:../.."
+    "react-native-branch": "^1.1.1"
   },
   "devDependencies": {
     "babel-jest": "18.0.0",

--- a/testbed/testbed_cocoapods/yarn.lock
+++ b/testbed/testbed_cocoapods/yarn.lock
@@ -2918,8 +2918,9 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-"react-native-branch@file:../..":
-  version "1.0.6"
+react-native-branch@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-1.1.1.tgz#6c330be833eca06b50034afb01dd6a4f1c8b595b"
 
 react-native@^0.42.0:
   version "0.42.0"

--- a/testbed/testbed_native_ios/README.md
+++ b/testbed/testbed_native_ios/README.md
@@ -1,6 +1,6 @@
 # testbed_native_ios
 
-This app illustrates how to integrate the react-native-branch SDK into a React Native component within an existing native iOS app.
+This app illustrates how to integrate the react-react-native-branch@2.0.0-beta.1-branch SDK into a React Native component within an existing native iOS app.
 
 The app was produced following the methodology outlined in these tutorials:
 

--- a/testbed/testbed_simple/README.md
+++ b/testbed/testbed_simple/README.md
@@ -1,11 +1,11 @@
 # testbed_simple
 
-This app illustrates the simplest means of integrating react-native-branch into a React Native app. This app was generated using the following commands:
+This app illustrates the simplest means of integrating react-native-branch@2.0.0-beta.1 into a React Native app. This app was generated using the following commands:
 
 ```bash
 react-native init testbed_simple
 cd testbed_simple
-npm install --save ../.. # from local repo
+npm install --save ../.. # from local repo. same as react-native-branch@2.0.0-beta.1
 react-native link
 ```
 


### PR DESCRIPTION
Keep the old testbed apps, but pin to `react-native-branch@^1.1.1` rather than using the repo contents. Update testbed docs.