### PR TITLE
Set contentIndexingMode to public in webview_example

### DIFF
--- a/examples/webview_example/src/Article.js
+++ b/examples/webview_example/src/Article.js
@@ -35,7 +35,8 @@ export default class Article extends Component {
       automaticallyListOnSpotlight: true, // ignored on Android
       canonicalUrl: this.props.route.url,
       title: this.props.route.title,
-      contentImageUrl: this.props.route.image
+      contentImageUrl: this.props.route.image,
+      contentIndexingMode: 'public' // for Spotlight indexing
     })
     this.buo.userCompletedAction(RegisterViewEvent)
     console.log("Created Branch Universal Object and logged RegisterViewEvent.")


### PR DESCRIPTION
Unlike the native SDKs, react-native-branch defaults contentIndexingMode to private. Spotlight indexing doesn't work unless it's public.