### PR TITLE
Cache rework (#79)

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -128,7 +128,6 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void redeemInitSessionResult(Promise promise) {
         promise.resolve(convertJsonToMap(initSessionResult));
-        initSessionResult = null;
     }
 
     @ReactMethod

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -156,8 +156,6 @@ RCT_EXPORT_METHOD(
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
     resolve(initSessionWithLaunchOptionsResult ? initSessionWithLaunchOptionsResult : [NSNull null]);
-    initSessionWithLaunchOptionsResult = nil;
-    sourceUrl = nil;
 }
 
 #pragma mark setDebug

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,6 @@ class Branch {
     if (this._timeSinceLaunch() < INIT_SESSION_TTL) {
       RNBranch.redeemInitSessionResult().then((result) => {
         if (result) {
-          this._dumpParams(result)
           listener(result)
         }
       })


### PR DESCRIPTION
- Removed all JS caching and subscription management, including _listeners.
- Stop resetting cache in redeemInitSessionResult.
- Use nativeEventEmitter.addListener, .removeListener directly with subscribe listener callback.