### PR TITLE
Improved Swift wrapper around RCTLog and friends.

### DIFF
--- a/examples/webview_example_native_ios/WebViewExample/RCTLog.swift
+++ b/examples/webview_example_native_ios/WebViewExample/RCTLog.swift
@@ -7,26 +7,21 @@
 //
 
 func RCTLogError(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    let fileName = file.components(separatedBy: "/").last!
-    RCTSwiftLog.error("[\(fileName):\(line)] \(message)")
+    RCTSwiftLog.error(message, file: file, line: line)
 }
 
 func RCTLogWarn(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    let fileName = file.components(separatedBy: "/").last!
-    RCTSwiftLog.warn("[\(fileName):\(line)] \(message)")
+    RCTSwiftLog.warn(message, file: file, line: line)
 }
 
 func RCTLogInfo(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    let fileName = file.components(separatedBy: "/").last!
-    RCTSwiftLog.info("[\(fileName):\(line)] \(message)")
+    RCTSwiftLog.info(message, file: file, line: line)
 }
 
 func RCTLog(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    let fileName = file.components(separatedBy: "/").last!
-    RCTSwiftLog.log("[\(fileName):\(line)] \(message)")
+    RCTSwiftLog.log(message, file: file, line: line)
 }
 
 func RCTLogTrace(_ message: String, _ file: String=#file, _ line: UInt=#line) {
-    let fileName = file.components(separatedBy: "/").last!
-    RCTSwiftLog.trace("[\(fileName):\(line)] \(message)")
+    RCTSwiftLog.trace(message, file: file, line: line)
 }

--- a/examples/webview_example_native_ios/WebViewExample/RCTLog.swift
+++ b/examples/webview_example_native_ios/WebViewExample/RCTLog.swift
@@ -6,6 +6,25 @@
 //  Copyright © 2017 Branch Metrics. All rights reserved.
 //
 
+/*
+ * Under at least some conditions, output from NSLog has been unavailable in the RNBranch module. 
+ * Hence that module uses the RCTLog macros from <React/RCTLog.h>. The React logger is nicer than 
+ * NSLog anyway, since it provides log levels with runtime filtering, file and line context and 
+ * an identifier for the thread that logged the message.
+ *
+ * This wrapper lets you use functions with the same name in Swift. For example:
+ *
+ * RCTLogInfo("application launched")
+ *
+ * generates
+ *
+ * 2017-04-06 12:31:09.611 [info][tid:main][AppDelegate.swift:18] application launched
+ *
+ * This is currently part of this sample app. There may be some issues integrating it into an
+ * Objective-C library, either react-native-branch or react-native itself, but it may find its
+ * way into one or the other eventually. Feel free to reuse it as desired.
+ */
+
 func RCTLogError(_ message: String, _ file: String=#file, _ line: UInt=#line) {
     RCTSwiftLog.error(message, file: file, line: line)
 }

--- a/examples/webview_example_native_ios/WebViewExample/RCTSwiftLog.h
+++ b/examples/webview_example_native_ios/WebViewExample/RCTSwiftLog.h
@@ -10,10 +10,10 @@
 
 @interface RCTSwiftLog : NSObject
 
-+ (void)error:(NSString * _Nonnull)message;
-+ (void)warn:(NSString * _Nonnull)message;
-+ (void)info:(NSString * _Nonnull)message;
-+ (void)log:(NSString * _Nonnull)message;
-+ (void)trace:(NSString * _Nonnull)message;
++ (void)error:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
++ (void)warn:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
++ (void)info:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
++ (void)log:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
++ (void)trace:(NSString * _Nonnull)message file:(NSString * _Nonnull)file line:(NSUInteger)line;
 
 @end

--- a/examples/webview_example_native_ios/WebViewExample/RCTSwiftLog.m
+++ b/examples/webview_example_native_ios/WebViewExample/RCTSwiftLog.m
@@ -12,29 +12,29 @@
 
 @implementation RCTSwiftLog
 
-+ (void)info:(NSString *)message
++ (void)info:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {
-    RCTLogInfo(@"%@", message);
+    _RCTLogNativeInternal(RCTLogLevelInfo, file.UTF8String, (int)line, @"%@", message);
 }
 
-+ (void)warn:(NSString *)message
++ (void)warn:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {
-    RCTLogWarn(@"%@", message);
+    _RCTLogNativeInternal(RCTLogLevelWarning, file.UTF8String, (int)line, @"%@", message);
 }
 
-+ (void)error:(NSString *)message
++ (void)error:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {
-    RCTLogError(@"%@", message);
+    _RCTLogNativeInternal(RCTLogLevelError, file.UTF8String, (int)line, @"%@", message);
 }
 
-+ (void)log:(NSString *)message
++ (void)log:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {
-    RCTLog(@"%@", message);
+    _RCTLogNativeInternal(RCTLogLevelInfo, file.UTF8String, (int)line, @"%@", message);
 }
 
-+ (void)trace:(NSString *)message
++ (void)trace:(NSString *)message file:(NSString *)file line:(NSUInteger)line
 {
-    RCTLogTrace(@"%@", message);
+    _RCTLogNativeInternal(RCTLogLevelTrace, file.UTF8String, (int)line, @"%@", message);
 }
 
 @end


### PR DESCRIPTION
Under at least some conditions, I have been unable to generate output from NSLog in the RNBranch module. Hence that module uses the RCTLog macros from <React/RCTLog.h>. The React logger is nicer than NSLog anyway, since it provides log levels with runtime filtering, file and line context and an identifier for the thread that logged the message.

This wrapper lets you use functions with the same name in Swift. For example:

```Swift
RCTLogInfo("application launched")
```

generates

```
2017-04-06 12:31:09.611 [info][tid:main][AppDelegate.swift:18] application launched
```

This is currently part of this sample app. There may be some issues integrating it into an Objective-C library, either react-native-branch or react-native itself, but it may find its way into one or the other eventually. Feel free to reuse it as desired.