### PR TITLE
Added an $ios_deepview control param to webview_examples

### DIFF
--- a/examples/webview_example/src/Article.js
+++ b/examples/webview_example/src/Article.js
@@ -75,7 +75,8 @@ export default class Article extends Component {
       feature: "share",
       channel: "RNApp"
     }, {
-      $desktop_url: this.props.route.url
+      $desktop_url: this.props.route.url,
+      $ios_deepview: "branch_default"
     })
 
     if (error) {

--- a/examples/webview_example_native_ios/src/Article.js
+++ b/examples/webview_example_native_ios/src/Article.js
@@ -75,7 +75,8 @@ export default class Article extends Component {
       feature: "share",
       channel: "RNApp"
     }, {
-      $desktop_url: this.props.route.url
+      $desktop_url: this.props.route.url,
+      $ios_deepview: "branch_default"
     })
 
     if (error) {


### PR DESCRIPTION
This has come up a few times recently and is useful to address a couple of different issues. It's nice to have an example.