### PR TITLE
Destructure subscribe

### DIFF
--- a/examples/testbed_carthage/src/Subscribe.js
+++ b/examples/testbed_carthage/src/Subscribe.js
@@ -2,20 +2,15 @@ import branch from 'react-native-branch'
 
 console.info("Subscribing to Branch links")
 
-branch.subscribe((bundle) => {
-  if (bundle.error) {
-    console.error("Error from Branch: " + bundle.error)
+branch.subscribe(({ error, params, uri }) => {
+  if (error) {
+    console.error("Error from Branch: " + error)
     return
   }
 
   console.info("Received link response from Branch")
 
-  console.log("params: " + bundle.params)
-  if (bundle.params) {
-    for (var property in bundle.params) {
-      console.log(" " + property + ": " + bundle.params[property])
-    }
-  }
+  console.log("params: " + JSON.stringify(params))
 
-  console.log("URI: " + bundle.uri)
+  console.log("URI: " + uri)
 })

--- a/examples/testbed_cocoapods/src/Subscribe.js
+++ b/examples/testbed_cocoapods/src/Subscribe.js
@@ -2,20 +2,15 @@ import branch from 'react-native-branch'
 
 console.info("Subscribing to Branch links")
 
-branch.subscribe((bundle) => {
-  if (bundle.error) {
-    console.error("Error from Branch: " + bundle.error)
+branch.subscribe(({ error, params, uri }) => {
+  if (error) {
+    console.error("Error from Branch: " + error)
     return
   }
 
   console.info("Received link response from Branch")
 
-  console.log("params: " + bundle.params)
-  if (bundle.params) {
-    for (var property in bundle.params) {
-      console.log(" " + property + ": " + bundle.params[property])
-    }
-  }
+  console.log("params: " + JSON.stringify(params))
 
-  console.log("URI: " + bundle.uri)
+  console.log("URI: " + uri)
 })

--- a/examples/testbed_simple/src/Subscribe.js
+++ b/examples/testbed_simple/src/Subscribe.js
@@ -2,20 +2,15 @@ import branch from 'react-native-branch'
 
 console.info("Subscribing to Branch links")
 
-branch.subscribe((bundle) => {
-  if (bundle.error) {
-    console.error("Error from Branch: " + bundle.error)
+branch.subscribe(({ error, params, uri }) => {
+  if (error) {
+    console.error("Error from Branch: " + error)
     return
   }
 
   console.info("Received link response from Branch")
 
-  console.log("params: " + bundle.params)
-  if (bundle.params) {
-    for (var property in bundle.params) {
-      console.log(" " + property + ": " + bundle.params[property])
-    }
-  }
+  console.log("params: " + JSON.stringify(params))
 
-  console.log("URI: " + bundle.uri)
+  console.log("URI: " + uri)
 })

--- a/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
+++ b/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		77869AD3634B415992A6FF6F /* RNBranch.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNBranch.xcodeproj; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		7BC69F431EA12D87000B04CE /* webview_example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = webview_example.entitlements; path = webview_example/webview_example.entitlements; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -400,6 +401,7 @@
 		13B07FAE1A68108700A75B9A /* webview_example */ = {
 			isa = PBXGroup;
 			children = (
+				7BC69F431EA12D87000B04CE /* webview_example.entitlements */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.m */,
@@ -589,7 +591,16 @@
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
 						CreatedOnToolsVersion = 6.2;
+						DevelopmentTeam = R63EM248DP;
 						TestTargetID = 13B07F861A680F5B00A75B9A;
+					};
+					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = R63EM248DP;
+						SystemCapabilities = {
+							com.apple.SafariKeychain = {
+								enabled = 1;
+							};
+						};
 					};
 					2D02E47A1E0B4A5D006451C7 = {
 						CreatedOnToolsVersion = 8.2.1;
@@ -990,6 +1001,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = R63EM248DP;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -1020,6 +1032,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = R63EM248DP;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-branch/ios/**",
@@ -1045,11 +1058,13 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = webview_example/webview_example.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = NO;
 				DEBUG_ACTIVITY_MODE = "";
 				"DEBUG_ACTIVITY_MODE[sdk=iphoneos*]" = disable;
 				"DEBUG_ACTIVITY_MODE[sdk=iphonesimulator*]" = disable;
+				DEVELOPMENT_TEAM = R63EM248DP;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-branch/ios/**",
@@ -1061,7 +1076,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = webview_example;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
@@ -1071,8 +1086,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = webview_example/webview_example.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_ACTIVITY_MODE = "";
+				DEVELOPMENT_TEAM = R63EM248DP;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(SRCROOT)/../node_modules/react-native-branch/ios/**",
@@ -1084,7 +1101,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = "io.branch.sdk.Branch-TestBed";
 				PRODUCT_NAME = webview_example;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/examples/webview_example/ios/webview_example/webview_example.entitlements
+++ b/examples/webview_example/ios/webview_example/webview_example.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:bnctestbed.app.link</string>
+		<string>applinks:bnctestbed-alternate.app.link</string>
+	</array>
+</dict>
+</plist>

--- a/examples/webview_example/src/App.js
+++ b/examples/webview_example/src/App.js
@@ -11,27 +11,22 @@ export default class App extends Component {
   navigator = null
 
   componentWillMount() {
-    this._unsubscribeFromBranch = branch.subscribe((bundle) => {
-      if (!bundle) return
-
-      if (bundle.error) {
-        console.error("Error opening Branch link: " + bundle.error)
+    this._unsubscribeFromBranch = branch.subscribe(({ error, params, uri }) => {
+      if (error) {
+        console.error("Error opening Branch link: " + error)
         return
       }
 
-      if (bundle.uri) console.log(bundle.uri + " opened via Branch")
+      if (uri) console.log(uri + " opened via Branch")
 
-      if (!bundle.params) return
+      if (!params) return
 
-      console.log("Branch link params:")
-      for (var param in bundle.params) {
-        console.log(" " + param + ": " + bundle.params[param])
-      }
+      console.log("Branch link params: " + JSON.stringify(params))
 
       // Get title and url for route
-      let title = bundle.params.$og_title
-      let url = bundle.params.$canonical_url
-      let image = bundle.params.$og_image_url
+      let title = params.$og_title
+      let url = params.$canonical_url
+      let image = params.$og_image_url
 
       // Now push the view for this URL
       this.navigator.push({ title: title, url: url, image: image })


### PR DESCRIPTION
Improve the way the subscribe callbacks are called in the example apps to reflect a recent change in the docs. This is basically a stylistic change that is more natural for JS devs, lines up with the way we call other methods and simplifies the app code. There is no change to the SDK or functional change to the example apps.