### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ install:
 # Set up RVM, RubyGems, Bundler
   - gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
   - rvm get head
-  - rvm install 2.3.4
-  - rvm use 2.3.4 --default
+  - rvm install 2.4.0
+  - rvm use 2.4.0 --default
   - gem update --system
   - gem install bundler
   - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source "https://rubygems.org"
 
-ruby "2.3.4"
-
 gem "cocoapods", "~> 1.2"
 gem "fastlane", "~> 2.26"
 gem "travis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,8 +216,5 @@ DEPENDENCIES
   fastlane (~> 2.26)
   travis
 
-RUBY VERSION
-   ruby 2.3.4p301
-
 BUNDLED WITH
    1.14.6


### PR DESCRIPTION
Use Ruby 2.4.0. 2.3.4 and 2.4.1 are both too recent to have precompiled binaries via RVM, so they add 6-7 minutes to the build time.

Removed ruby declaration from Gemfile, which is confusing and inconvenient.