### PR TITLE
Added eslint to .travis.yml and runAllTests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ script:
   # Requires Android SDK
   # - bundle exec fastlane test_android
   - bundle exec fastlane test_ios
+  - npm run lint
   - npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Before submitting a PR, test the new functionality or bugfix in android & ios, a
 
 ### Testing and Linting
 
-All contributions must pass `eslint` and `npm test` before being accepted.
+All contributions must pass `npm run lint` and `npm test` before being accepted.
 
 #### Native Unit Tests
 
@@ -33,7 +33,7 @@ bundle exec fastlane test_android
 bundle exec fastlane test_ios
 ```
 
-There is also a `runAllTests` script at the repository root for convenience, which also runs `npm test`.
+There is also a `runAllTests` script at the repository root for convenience, which also runs `npm run lint` and `npm test`.
 
 Notes on native unit tests and Fastlane:
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-native-branch.podspec"
   ],
   "scripts": {
+    "lint": "eslint src test",
     "test": "ava"
   },
   "ava": {

--- a/runAllTests
+++ b/runAllTests
@@ -30,6 +30,7 @@ bundle install
 
 bundle exec fastlane test_android
 bundle exec fastlane test_ios
+npm run lint
 npm test
 
 exit 0

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -50,7 +50,7 @@ export default async function createBranchUniversalObject(identifier, options = 
 
     _tryFunction(func, ...args) {
       return func(this.ident, ...args).catch((error) => {
-        if (error.code != "RNBranch::Error::BUONotFound") {
+        if (error.code != 'RNBranch::Error::BUONotFound') {
           throw error
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,12 @@ import createBranchUniversalObject from './branchUniversalObject'
 
 export const DEFAULT_INIT_SESSION_TTL = 5000
 
-export const AddToWishlistEvent = "Add to Wishlist"
-export const PurchasedEvent = "Purchased"
-export const PurchaseInitiatedEvent = "Purchase Started"
-export const RegisterViewEvent = "View"
-export const ShareCompletedEvent = "Share Completed"
-export const ShareInitiatedEvent = "Share Started"
+export const AddToWishlistEvent = 'Add to Wishlist'
+export const PurchasedEvent = 'Purchased'
+export const PurchaseInitiatedEvent = 'Purchase Started'
+export const RegisterViewEvent = 'View'
+export const ShareCompletedEvent = 'Share Completed'
+export const ShareInitiatedEvent = 'Share Started'
 
 class Branch {
   nativeEventEmitter = Platform.select({
@@ -55,7 +55,7 @@ class Branch {
          * initial cached value, which essentially eliminates all possibility of
          * getting the same event twice.
          */
-         this._addListener(listener)
+        this._addListener(listener)
       })
     }
     else {

--- a/test/index.js
+++ b/test/index.js
@@ -20,10 +20,10 @@ test('subscribe does not return init session beyond the TTL', t => {
   branch.initSessionTtl = 0 // disable the cache check in this test
 
   return new Promise((resolve, reject) => {
-    var listenerWasCalled = false
+    let listenerWasCalled = false
     branch.subscribe(({ error, params, uri }) => {
       listenerWasCalled = true
-      reject("subscribe listener should not be called")
+      reject('subscribe listener should not be called')
     })
 
     setTimeout(() => {
@@ -61,7 +61,7 @@ test.serial('subscribe does not add an event listener within the TTL until redee
     branch.subscribe(({error, params, uri}) => {})
 
     setTimeout(() => {
-      this.listenerAdded ? resolve() : reject("listener was not added")
+      this.listenerAdded ? resolve() : reject('listener was not added')
 
       emitter.addListener = originalAddListener
       RNBranch.redeemInitSessionResult = originalRedeemInitSessionResult
@@ -85,7 +85,7 @@ test.serial('after the TTL, subscribe adds a listener and does not call redeemIn
   // Modify RNBranch.redeemInitSessionResult to check whether it is called at all
   const originalRedeemInitSessionResult = RNBranch.redeemInitSessionResult
   RNBranch.redeemInitSessionResult = () => {
-    t.fail("redeemInitSessionResult should not be called")
+    t.fail('redeemInitSessionResult should not be called')
     return new Promise((resolve, reject) => {
       resolve({})
     })
@@ -97,7 +97,7 @@ test.serial('after the TTL, subscribe adds a listener and does not call redeemIn
     branch.subscribe(({error, params, uri}) => {})
 
     setTimeout(() => {
-      this.listenerAdded ? resolve() : reject("listener was not added")
+      this.listenerAdded ? resolve() : reject('listener was not added')
 
       emitter.addListener = originalAddListener
       RNBranch.redeemInitSessionResult = originalRedeemInitSessionResult


### PR DESCRIPTION
The contribution instructions say all contributions must pass eslint. There is now a lint script in package.json. This was added to CI (.travis.yml) and the runAllTests script. The contribution instructions were updated to use `npm run lint`.

A number of eslint violations were also fixed.