### PR TITLE
Event constants

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -42,6 +42,13 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static final String RN_INIT_SESSION_ERROR_EVENT = "RNBranch.initSessionError";
     private static final String INIT_SESSION_SUCCESS = "INIT_SESSION_SUCCESS";
     private static final String INIT_SESSION_ERROR = "INIT_SESSION_ERROR";
+    private static final String ADD_TO_CART_EVENT = "ADD_TO_CART_EVENT";
+    private static final String ADD_TO_WISHLIST_EVENT = "ADD_TO_WISHLIST_EVENT";
+    private static final String PURCHASED_EVENT = "PURCHASED_EVENT";
+    private static final String PURCHASE_INITIATED_EVENT = "PURCHASE_INITIATED_EVENT";
+    private static final String REGISTER_VIEW_EVENT = "REGISTER_VIEW_EVENT";
+    private static final String SHARE_COMPLETED_EVENT = "SHARE_COMPLETED_EVENT";
+    private static final String SHARE_INITIATED_EVENT = "SHARE_INITIATED_EVENT";
     private static final String IDENT_FIELD_NAME = "ident";
     public static final String UNIVERSAL_OBJECT_NOT_FOUND_ERROR_CODE = "RNBranch::Error::BUONotFound";
     private static final long AGING_HASH_TTL = 3600000;
@@ -139,8 +146,17 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     @Override
     public Map<String, Object> getConstants() {
         final Map<String, Object> constants = new HashMap<>();
+        // RN events transmitted to JS
         constants.put(INIT_SESSION_SUCCESS, RN_INIT_SESSION_SUCCESS_EVENT);
         constants.put(INIT_SESSION_ERROR, RN_INIT_SESSION_ERROR_EVENT);
+        // Constants for use with userCompletedAction
+        constants.put(ADD_TO_CART_EVENT, BranchEvent.ADD_TO_CART);
+        constants.put(ADD_TO_WISHLIST_EVENT, BranchEvent.ADD_TO_WISH_LIST);
+        constants.put(PURCHASED_EVENT, BranchEvent.PURCHASED);
+        constants.put(PURCHASE_INITIATED_EVENT, BranchEvent.PURCHASE_STARTED);
+        constants.put(REGISTER_VIEW_EVENT, BranchEvent.VIEW);
+        constants.put(SHARE_COMPLETED_EVENT, BranchEvent.SHARE_COMPLETED);
+        constants.put(SHARE_INITIATED_EVENT, BranchEvent.SHARE_STARTED);
         return constants;
     }
 

--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -7,8 +7,6 @@ extern NSString * const RNBranchLinkOpenedNotificationParamsKey;
 extern NSString * const RNBranchLinkOpenedNotificationUriKey;
 extern NSString * const RNBranchLinkOpenedNotificationBranchUniversalObjectKey;
 extern NSString * const RNBranchLinkOpenedNotificationLinkPropertiesKey;
-extern NSString * const kRNBranchInitSessionSuccess;
-extern NSString * const kRNBranchInitSessionError;
 
 @interface RNBranch : NSObject <RCTBridgeModule>
 

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -14,10 +14,6 @@ NSString * const RNBranchLinkOpenedNotificationUriKey = @"uri";
 NSString * const RNBranchLinkOpenedNotificationBranchUniversalObjectKey = @"branch_universal_object";
 NSString * const RNBranchLinkOpenedNotificationLinkPropertiesKey = @"link_properties";
 
-// Notification/Event Names
-NSString * const kRNBranchInitSessionSuccess = @"RNBranch.initSessionSuccess";
-NSString * const kRNBranchInitSessionError = @"RNBranch.initSessionError";
-
 static NSDictionary *initSessionWithLaunchOptionsResult;
 static NSURL *sourceUrl;
 static Branch *branchInstance;
@@ -44,9 +40,20 @@ static NSInteger const RNBranchUniversalObjectNotFoundError = 1;
 RCT_EXPORT_MODULE();
 
 - (NSDictionary<NSString *, NSString *> *)constantsToExport {
-    return @{ @"INIT_SESSION_SUCCESS": kRNBranchInitSessionSuccess,
-              @"INIT_SESSION_ERROR": kRNBranchInitSessionError,
-              };
+    return @{
+             // RN events transmitted to JS by event emitter
+             @"INIT_SESSION_SUCCESS": kRNBranchInitSessionSuccess,
+             @"INIT_SESSION_ERROR": kRNBranchInitSessionError,
+
+             // constants for use with userCompletedAction
+             @"ADD_TO_CART_EVENT": BNCAddToCartEvent,
+             @"ADD_TO_WISHLIST_EVENT": BNCAddToWishlistEvent,
+             @"PURCHASED_EVENT": BNCPurchasedEvent,
+             @"PURCHASE_INITIATED_EVENT": BNCPurchaseInitiatedEvent,
+             @"REGISTER_VIEW_EVENT": BNCRegisterViewEvent,
+             @"SHARE_COMPLETED_EVENT": BNCShareCompletedEvent,
+             @"SHARE_INITIATED_EVENT": BNCShareInitiatedEvent
+             };
 }
 
 #pragma mark - Class methods

--- a/ios/RNBranchEventEmitter.h
+++ b/ios/RNBranchEventEmitter.h
@@ -9,6 +9,9 @@
 #import <React/RCTEventEmitter.h>
 #import <React/RCTBridge.h>
 
+extern NSString * const kRNBranchInitSessionSuccess;
+extern NSString * const kRNBranchInitSessionError;
+
 @interface RNBranchEventEmitter : RCTEventEmitter<RCTBridgeModule>
 
 + (void)initSessionDidSucceedWithPayload:(NSDictionary<NSString *, id> *)payload;

--- a/ios/RNBranchEventEmitter.m
+++ b/ios/RNBranchEventEmitter.m
@@ -11,6 +11,10 @@
 #import "RNBranch.h"
 #import "RNBranchEventEmitter.h"
 
+// Notification/Event Names
+NSString * const kRNBranchInitSessionSuccess = @"RNBranch.initSessionSuccess";
+NSString * const kRNBranchInitSessionError = @"RNBranch.initSessionError";
+
 @interface RNBranchEventEmitter()
 @property (nonatomic) BOOL hasListeners;
 @end

--- a/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
+++ b/native-tests/ios/NativeTests.xcodeproj/project.pbxproj
@@ -16,7 +16,8 @@
 		7B7C90E31EA6E07C005B470E /* NSObjectExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7C90E21EA6E07C005B470E /* NSObjectExtensionTests.m */; };
 		7B7C90E51EA6E496005B470E /* BranchUniversalObjectExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7C90E41EA6E496005B470E /* BranchUniversalObjectExtensionTests.m */; };
 		7B7C90E71EA6E71E005B470E /* RNBranchPropertyTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7C90E61EA6E71E005B470E /* RNBranchPropertyTests.m */; };
-		7B7C90E91EA6EC8C005B470E /* BranchLinkPropertiesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7C90E81EA6EC8C005B470E /* BranchLinkPropertiesTests.m */; };
+		7B7C90E91EA6EC8C005B470E /* BranchLinkPropertiesExtensionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7C90E81EA6EC8C005B470E /* BranchLinkPropertiesExtensionTests.m */; };
+		7BAD46FB1EAA66E700080008 /* RNBranchTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BAD46FA1EAA66E700080008 /* RNBranchTests.m */; };
 		7BCEC8B01E9FE59A00271263 /* RNBranchAgingDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BCEC8AF1E9FE59A00271263 /* RNBranchAgingDictionaryTests.m */; };
 		DE336E58F740599D27E8A89C /* libPods-NativeTestsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = FDF1BD18E75D3D23CEB8AFF0 /* libPods-NativeTestsTests.a */; };
 		E3358048CB314A416B25FC42 /* libPods-NativeTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82030DF006224ED018AB53F3 /* libPods-NativeTests.a */; };
@@ -50,7 +51,8 @@
 		7B7C90E21EA6E07C005B470E /* NSObjectExtensionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSObjectExtensionTests.m; sourceTree = "<group>"; };
 		7B7C90E41EA6E496005B470E /* BranchUniversalObjectExtensionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchUniversalObjectExtensionTests.m; sourceTree = "<group>"; };
 		7B7C90E61EA6E71E005B470E /* RNBranchPropertyTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchPropertyTests.m; sourceTree = "<group>"; };
-		7B7C90E81EA6EC8C005B470E /* BranchLinkPropertiesTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchLinkPropertiesTests.m; sourceTree = "<group>"; };
+		7B7C90E81EA6EC8C005B470E /* BranchLinkPropertiesExtensionTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BranchLinkPropertiesExtensionTests.m; sourceTree = "<group>"; };
+		7BAD46FA1EAA66E700080008 /* RNBranchTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchTests.m; sourceTree = "<group>"; };
 		7BCEC8AF1E9FE59A00271263 /* RNBranchAgingDictionaryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNBranchAgingDictionaryTests.m; sourceTree = "<group>"; };
 		82030DF006224ED018AB53F3 /* libPods-NativeTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-NativeTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		9AC315A7D8A410E2C48CFEEA /* Pods-NativeTestsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NativeTestsTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-NativeTestsTests/Pods-NativeTestsTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -136,11 +138,12 @@
 		7B23B67E1E9FDCEB006CEE75 /* NativeTestsTests */ = {
 			isa = PBXGroup;
 			children = (
-				7B7C90E81EA6EC8C005B470E /* BranchLinkPropertiesTests.m */,
+				7B7C90E81EA6EC8C005B470E /* BranchLinkPropertiesExtensionTests.m */,
 				7B7C90E41EA6E496005B470E /* BranchUniversalObjectExtensionTests.m */,
 				7B7C90E21EA6E07C005B470E /* NSObjectExtensionTests.m */,
 				7BCEC8AF1E9FE59A00271263 /* RNBranchAgingDictionaryTests.m */,
 				7B7C90E61EA6E71E005B470E /* RNBranchPropertyTests.m */,
+				7BAD46FA1EAA66E700080008 /* RNBranchTests.m */,
 				7B23B6811E9FDCEB006CEE75 /* Info.plist */,
 			);
 			path = NativeTestsTests;
@@ -369,10 +372,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B7C90E71EA6E71E005B470E /* RNBranchPropertyTests.m in Sources */,
-				7B7C90E91EA6EC8C005B470E /* BranchLinkPropertiesTests.m in Sources */,
+				7B7C90E91EA6EC8C005B470E /* BranchLinkPropertiesExtensionTests.m in Sources */,
 				7BCEC8B01E9FE59A00271263 /* RNBranchAgingDictionaryTests.m in Sources */,
 				7B7C90E31EA6E07C005B470E /* NSObjectExtensionTests.m in Sources */,
 				7B7C90E51EA6E496005B470E /* BranchUniversalObjectExtensionTests.m in Sources */,
+				7BAD46FB1EAA66E700080008 /* RNBranchTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/native-tests/ios/NativeTestsTests/BranchLinkPropertiesExtensionTests.m
+++ b/native-tests/ios/NativeTestsTests/BranchLinkPropertiesExtensionTests.m
@@ -1,5 +1,5 @@
 //
-//  BranchLinkPropertiesTests.m
+//  BranchLinkPropertiesExtensionTests.m
 //  NativeTests
 //
 //  Created by Jimmy Dee on 4/18/17.
@@ -12,11 +12,11 @@
 #import <react-native-branch/BranchLinkProperties+RNBranch.h>
 #import <react-native-branch/RNBranchProperty.h>
 
-@interface BranchLinkPropertiesTests : XCTestCase
+@interface BranchLinkPropertiesExtensionTests : XCTestCase
 
 @end
 
-@implementation BranchLinkPropertiesTests
+@implementation BranchLinkPropertiesExtensionTests
 
 - (void)testFieldMapping
 {

--- a/native-tests/ios/NativeTestsTests/RNBranchTests.m
+++ b/native-tests/ios/NativeTestsTests/RNBranchTests.m
@@ -1,0 +1,81 @@
+//
+//  RNBranchTests.m
+//  NativeTests
+//
+//  Created by Jimmy Dee on 4/21/17.
+//  Copyright © 2017 Branch Metrics. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import <react-native-branch/RNBranch.h>
+#import <react-native-branch/RNBranchEventEmitter.h>
+#import <Branch/Branch.h>
+
+@interface RNBranchTests : XCTestCase
+@property (nonatomic) RNBranch *rnbranch;
+@end
+
+@implementation RNBranchTests
+
+- (void)setUp {
+    [super setUp];
+    self.rnbranch = [[RNBranch alloc] init];
+}
+
+#pragma mark - Exported constants
+
+- (void)testInitSessionSuccessConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"INIT_SESSION_SUCCESS"];
+    XCTAssertEqual(kRNBranchInitSessionSuccess, constant);
+}
+
+- (void)testInitSessionErrorConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"INIT_SESSION_ERROR"];
+    XCTAssertEqual(kRNBranchInitSessionError, constant);
+}
+
+- (void)testAddToCartEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"ADD_TO_CART_EVENT"];
+    XCTAssertEqual(BNCAddToCartEvent, constant);
+}
+
+- (void)testAddToWishlistEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"ADD_TO_WISHLIST_EVENT"];
+    XCTAssertEqual(BNCAddToWishlistEvent, constant);
+}
+
+- (void)testPurchasedEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"PURCHASED_EVENT"];
+    XCTAssertEqual(BNCPurchasedEvent, constant);
+}
+
+- (void)testPurchaseInitiatedEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"PURCHASE_INITIATED_EVENT"];
+    XCTAssertEqual(BNCPurchaseInitiatedEvent, constant);
+}
+
+- (void)testRegisterViewEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"REGISTER_VIEW_EVENT"];
+    XCTAssertEqual(BNCRegisterViewEvent, constant);
+}
+
+- (void)testShareCompletedEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"SHARE_COMPLETED_EVENT"];
+    XCTAssertEqual(BNCShareCompletedEvent, constant);
+}
+
+- (void)testShareInitiatedEventConstant
+{
+    NSString *constant = self.rnbranch.constantsToExport[@"SHARE_INITIATED_EVENT"];
+    XCTAssertEqual(BNCShareInitiatedEvent, constant);
+}
+
+@end

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,13 @@ import createBranchUniversalObject from './branchUniversalObject'
 
 export const DEFAULT_INIT_SESSION_TTL = 5000
 
-export const AddToWishlistEvent = 'Add to Wishlist'
-export const PurchasedEvent = 'Purchased'
-export const PurchaseInitiatedEvent = 'Purchase Started'
-export const RegisterViewEvent = 'View'
-export const ShareCompletedEvent = 'Share Completed'
-export const ShareInitiatedEvent = 'Share Started'
+export const AddToCartEvent = RNBranch.ADD_TO_CART_EVENT
+export const AddToWishlistEvent = RNBranch.ADD_TO_WISHLIST_EVENT
+export const PurchasedEvent = RNBranch.PURCHASED_EVENT
+export const PurchaseInitiatedEvent = RNBranch.PURCHASE_INITIATED_EVENT
+export const RegisterViewEvent = RNBranch.REGISTER_VIEW_EVENT
+export const ShareCompletedEvent = RNBranch.SHARE_COMPLETED_EVENT
+export const ShareInitiatedEvent = RNBranch.SHARE_INITIATED_EVENT
 
 class Branch {
   nativeEventEmitter = Platform.select({

--- a/test/helpers/RNBranch.mock.js
+++ b/test/helpers/RNBranch.mock.js
@@ -3,6 +3,15 @@ import React from 'react-native'
 const defaultSession = {params: {}, error: null}
 
 React.NativeModules.RNBranch = {
+  // Mock constants exported by native layers
+  ADD_TO_CART_EVENT: 'Add to Cart',
+  ADD_TO_WISHLIST_EVENT: 'Add to Wishlist',
+  PURCHASE_INITIATED_EVENT: 'Purchase Started',
+  PURCHASED_EVENT: 'Purchased',
+  REGISTER_VIEW_EVENT: 'View',
+  SHARE_COMPLETED_EVENT: 'Share Completed',
+  SHARE_INITIATED_EVENT: 'Share Started',
+
   redeemInitSessionResult() {
     return new Promise((resolve, reject) => {
       setTimeout(() => resolve(defaultSession), 500)

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,16 @@ import test from 'ava'
 import React from 'react-native'
 const { RNBranch } = React.NativeModules
 
-import branch, { DEFAULT_INIT_SESSION_TTL } from '../src/index.js'
+import branch, {
+  AddToCartEvent,
+  AddToWishlistEvent,
+  PurchasedEvent,
+  PurchaseInitiatedEvent,
+  RegisterViewEvent,
+  ShareCompletedEvent,
+  ShareInitiatedEvent,
+  DEFAULT_INIT_SESSION_TTL
+} from '../src/index.js'
 
 test.beforeEach(() => {
   branch.initSessionTtl = DEFAULT_INIT_SESSION_TTL
@@ -104,4 +113,33 @@ test.serial('after the TTL, subscribe adds a listener and does not call redeemIn
     }, 100)
   })
 
+})
+
+// constant mapping
+test('AddToCartEvent is correct', t => {
+  t.is(RNBranch.ADD_TO_CART_EVENT, AddToCartEvent)
+})
+
+test('AddToWishlistEvent is correct', t => {
+  t.is(RNBranch.ADD_TO_WISHLIST_EVENT, AddToWishlistEvent)
+})
+
+test('PurchasedEvent is correct', t => {
+  t.is(RNBranch.PURCHASED_EVENT, PurchasedEvent)
+})
+
+test('PurchaseInitiatedEvent is correct', t => {
+  t.is(RNBranch.PURCHASE_INITIATED_EVENT, PurchaseInitiatedEvent)
+})
+
+test('RegisterViewEvent is correct', t => {
+  t.is(RNBranch.REGISTER_VIEW_EVENT, RegisterViewEvent)
+})
+
+test('ShareCompletedEvent is correct', t => {
+  t.is(RNBranch.SHARE_COMPLETED_EVENT, ShareCompletedEvent)
+})
+
+test('ShareInitiatedEvent is correct', t => {
+  t.is(RNBranch.SHARE_INITIATED_EVENT, ShareInitiatedEvent)
 })


### PR DESCRIPTION
Eliminate constants in JS that duplicate constants in the native SDKs in favor of exported constants for better consistency. Added missing AddToCartEvent. Added unit tests in JS and Obj-C for these mappings. Android tests of the RNBranchModule require testing in an emulator, which still remains to be set up.