### PR TITLE
Improvements to iOS unit tests

### DIFF
--- a/native-tests/ios/NativeTestsTests/BranchLinkPropertiesExtensionTests.m
+++ b/native-tests/ios/NativeTestsTests/BranchLinkPropertiesExtensionTests.m
@@ -49,15 +49,15 @@
                                                                                    @"tags" : @[ @"tag1", @"tag2" ]
                                                                                    }];
 
-    XCTAssertEqual(@"alias", properties.alias);
-    XCTAssertEqual(@"campaign", properties.campaign);
-    XCTAssertEqual(@"channel", properties.channel);
-    XCTAssertEqual(@"feature", properties.feature);
-    XCTAssertEqual(@"stage", properties.stage);
+    XCTAssertEqualObjects(@"alias", properties.alias);
+    XCTAssertEqualObjects(@"campaign", properties.campaign);
+    XCTAssertEqualObjects(@"channel", properties.channel);
+    XCTAssertEqualObjects(@"feature", properties.feature);
+    XCTAssertEqualObjects(@"stage", properties.stage);
 
     XCTAssertEqual(2, properties.tags.count);
-    XCTAssertEqual(@"tag1", properties.tags[0]);
-    XCTAssertEqual(@"tag2", properties.tags[1]);
+    XCTAssertEqualObjects(@"tag1", properties.tags[0]);
+    XCTAssertEqualObjects(@"tag2", properties.tags[1]);
 }
 
 @end

--- a/native-tests/ios/NativeTestsTests/BranchUniversalObjectExtensionTests.m
+++ b/native-tests/ios/NativeTestsTests/BranchUniversalObjectExtensionTests.m
@@ -73,25 +73,25 @@
     strptime(expirationDate.UTF8String, "%Y-%m-%dT%H:%M:%S", &expiration);
     NSTimeInterval expectedExpiration = timegm(&expiration);
 
-    XCTAssertEqual(@"abc", buo.canonicalIdentifier);
+    XCTAssertEqualObjects(@"abc", buo.canonicalIdentifier);
     XCTAssert(buo.automaticallyListOnSpotlight);
-    XCTAssertEqual(@"canonicalUrl", buo.canonicalUrl);
-    XCTAssertEqual(@"contentDescription", buo.contentDescription);
-    XCTAssertEqual(@"contentImageUrl", buo.imageUrl);
+    XCTAssertEqualObjects(@"canonicalUrl", buo.canonicalUrl);
+    XCTAssertEqualObjects(@"contentDescription", buo.contentDescription);
+    XCTAssertEqualObjects(@"contentImageUrl", buo.imageUrl);
     XCTAssertEqual(ContentIndexModePublic, buo.contentIndexMode);
-    XCTAssertEqual(@"currency", buo.currency);
+    XCTAssertEqualObjects(@"currency", buo.currency);
     XCTAssertEqual(expectedExpiration, buo.expirationDate.timeIntervalSince1970);
 
     XCTAssertEqual(2, buo.keywords.count);
-    XCTAssertEqual(@"keyword1", buo.keywords[0]);
-    XCTAssertEqual(@"keyword2", buo.keywords[1]);
+    XCTAssertEqualObjects(@"keyword1", buo.keywords[0]);
+    XCTAssertEqualObjects(@"keyword2", buo.keywords[1]);
 
     XCTAssertEqual(2, buo.metadata.allKeys.count);
-    XCTAssertEqual(@"value1", buo.metadata[@"key1"]);
-    XCTAssertEqual(@"value2", buo.metadata[@"key2"]);
+    XCTAssertEqualObjects(@"value1", buo.metadata[@"key1"]);
+    XCTAssertEqualObjects(@"value2", buo.metadata[@"key2"]);
 
-    XCTAssertEqual(@"title", buo.title);
-    XCTAssertEqual(@"type", buo.type);
+    XCTAssertEqualObjects(@"title", buo.title);
+    XCTAssertEqualObjects(@"type", buo.type);
 }
 
 #pragma mark - Content indexing mode

--- a/native-tests/ios/NativeTestsTests/NSObjectExtensionTests.m
+++ b/native-tests/ios/NativeTestsTests/NSObjectExtensionTests.m
@@ -40,7 +40,7 @@
 {
     [self.testClass setSupportedPropertiesWithMap:@{ @"foo": @"bar" }];
 
-    XCTAssertEqual(@"bar", self.testClass.foo);
+    XCTAssertEqualObjects(@"bar", self.testClass.foo);
 }
 
 - (void)testUnsupportedProperty

--- a/native-tests/ios/NativeTestsTests/RNBranchAgingDictionaryTests.m
+++ b/native-tests/ios/NativeTestsTests/RNBranchAgingDictionaryTests.m
@@ -35,15 +35,16 @@
 {
     RNBranchAgingDictionary *dictionary = [RNBranchAgingDictionary dictionaryWithTtl:3600.0];
 
-    dictionary[@"key1"] = @"value1";
-    [dictionary setObject:@"value2" forKey:@"key2"];
+    NSString *value1 = @"value1", *value2 = @"value2";
+    dictionary[@"key1"] = value1;
+    [dictionary setObject:value2 forKey:@"key2"];
 
     // access returns a value if the key is present and has not expired.
-    XCTAssertEqual(@"value1", dictionary[@"key1"]);
-    XCTAssertEqual(@"value1", [dictionary objectForKey:@"key1"]);
+    XCTAssertEqual(value1, dictionary[@"key1"]);
+    XCTAssertEqual(value1, [dictionary objectForKey:@"key1"]);
 
-    XCTAssertEqual(@"value2", dictionary[@"key2"]);
-    XCTAssertEqual(@"value2", [dictionary objectForKey:@"key2"]);
+    XCTAssertEqual(value2, dictionary[@"key2"]);
+    XCTAssertEqual(value2, [dictionary objectForKey:@"key2"]);
 }
 
 - (void)testRemoval

--- a/native-tests/ios/NativeTestsTests/RNBranchAgingItemTests.m
+++ b/native-tests/ios/NativeTestsTests/RNBranchAgingItemTests.m
@@ -18,8 +18,9 @@
 
 - (void)testInitialization
 {
+    NSString *expected = @"abc";
     NSTimeInterval beforeInitialization = [NSDate date].timeIntervalSince1970;
-    RNBranchAgingItem *item = [[RNBranchAgingItem alloc] initWithItem:@"abc"];
+    RNBranchAgingItem *item = [[RNBranchAgingItem alloc] initWithItem:expected];
     NSTimeInterval afterInitialization = [NSDate date].timeIntervalSince1970;
 
     // Access time initialized to initialization time.
@@ -27,12 +28,13 @@
     XCTAssertLessThanOrEqual(item.accessTime, afterInitialization);
 
     // item property returns the constructor argument.
-    XCTAssertEqual(@"abc", item.item);
+    XCTAssertEqual(expected, item.item);
 }
 
 - (void)testAccessTime
 {
-    RNBranchAgingItem *item = [[RNBranchAgingItem alloc] initWithItem:@"abc"];
+    NSString *expected = @"abc";
+    RNBranchAgingItem *item = [[RNBranchAgingItem alloc] initWithItem:expected];
     NSTimeInterval afterInitialization = [NSDate date].timeIntervalSince1970;
 
     usleep(10000); // sleep for 10 ms
@@ -45,7 +47,7 @@
     XCTAssertLessThanOrEqual(item.accessTime, afterAccess);
 
     // Avoid a complaint about an unused variable.
-    XCTAssertEqual(@"abc", value);
+    XCTAssertEqual(expected, value);
 }
 
 @end

--- a/native-tests/ios/NativeTestsTests/RNBranchTests.m
+++ b/native-tests/ios/NativeTestsTests/RNBranchTests.m
@@ -27,55 +27,55 @@
 - (void)testInitSessionSuccessConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"INIT_SESSION_SUCCESS"];
-    XCTAssertEqual(kRNBranchInitSessionSuccess, constant);
+    XCTAssertEqualObjects(kRNBranchInitSessionSuccess, constant);
 }
 
 - (void)testInitSessionErrorConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"INIT_SESSION_ERROR"];
-    XCTAssertEqual(kRNBranchInitSessionError, constant);
+    XCTAssertEqualObjects(kRNBranchInitSessionError, constant);
 }
 
 - (void)testAddToCartEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"ADD_TO_CART_EVENT"];
-    XCTAssertEqual(BNCAddToCartEvent, constant);
+    XCTAssertEqualObjects(BNCAddToCartEvent, constant);
 }
 
 - (void)testAddToWishlistEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"ADD_TO_WISHLIST_EVENT"];
-    XCTAssertEqual(BNCAddToWishlistEvent, constant);
+    XCTAssertEqualObjects(BNCAddToWishlistEvent, constant);
 }
 
 - (void)testPurchasedEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"PURCHASED_EVENT"];
-    XCTAssertEqual(BNCPurchasedEvent, constant);
+    XCTAssertEqualObjects(BNCPurchasedEvent, constant);
 }
 
 - (void)testPurchaseInitiatedEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"PURCHASE_INITIATED_EVENT"];
-    XCTAssertEqual(BNCPurchaseInitiatedEvent, constant);
+    XCTAssertEqualObjects(BNCPurchaseInitiatedEvent, constant);
 }
 
 - (void)testRegisterViewEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"REGISTER_VIEW_EVENT"];
-    XCTAssertEqual(BNCRegisterViewEvent, constant);
+    XCTAssertEqualObjects(BNCRegisterViewEvent, constant);
 }
 
 - (void)testShareCompletedEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"SHARE_COMPLETED_EVENT"];
-    XCTAssertEqual(BNCShareCompletedEvent, constant);
+    XCTAssertEqualObjects(BNCShareCompletedEvent, constant);
 }
 
 - (void)testShareInitiatedEventConstant
 {
     NSString *constant = self.rnbranch.constantsToExport[@"SHARE_INITIATED_EVENT"];
-    XCTAssertEqual(BNCShareInitiatedEvent, constant);
+    XCTAssertEqualObjects(BNCShareInitiatedEvent, constant);
 }
 
 @end


### PR DESCRIPTION
Use XCTAssertEqualObjects when semantically appropriate rather than XCTAssertEqual.