### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+native-tests/


### PR DESCRIPTION
ignore native-tests library when using the npm package