### PR TITLE
Data model updates

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -25,8 +25,6 @@ import io.branch.indexing.*;
 import org.json.*;
 
 import java.lang.ref.WeakReference;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;

--- a/examples/testbed_native_android/src/Subscribe.js
+++ b/examples/testbed_native_android/src/Subscribe.js
@@ -2,20 +2,13 @@ import branch from 'react-native-branch'
 
 console.info("Subscribing to Branch links")
 
-branch.subscribe((bundle) => {
-  if (bundle.error) {
-    console.error("Error from Branch: " + bundle.error)
+branch.subscribe(({ error, params }) => {
+  if (error) {
+    console.error("Error from Branch: " + error)
     return
   }
 
   console.info("Received link response from Branch")
 
-  console.log("params: " + bundle.params)
-  if (bundle.params) {
-    for (var property in bundle.params) {
-      console.log(" " + property + ": " + bundle.params[property])
-    }
-  }
-
-  console.log("URI: " + bundle.uri)
+  console.log("params: " + JSON.stringify(params))
 })

--- a/examples/testbed_native_ios/src/Subscribe.js
+++ b/examples/testbed_native_ios/src/Subscribe.js
@@ -2,20 +2,13 @@ import branch from 'react-native-branch'
 
 console.info("Subscribing to Branch links")
 
-branch.subscribe((bundle) => {
-  if (bundle.error) {
-    console.error("Error from Branch: " + bundle.error)
+branch.subscribe(({ error, params }) => {
+  if (error) {
+    console.error("Error from Branch: " + error)
     return
   }
 
   console.info("Received link response from Branch")
 
-  console.log("params: " + bundle.params)
-  if (bundle.params) {
-    for (var property in bundle.params) {
-      console.log(" " + property + ": " + bundle.params[property])
-    }
-  }
-
-  console.log("URI: " + bundle.uri)
+  console.log("params: " + JSON.stringify(params))
 })

--- a/examples/testbed_simple/src/Subscribe.js
+++ b/examples/testbed_simple/src/Subscribe.js
@@ -2,7 +2,7 @@ import branch from 'react-native-branch'
 
 console.info("Subscribing to Branch links")
 
-branch.subscribe(({ error, params, uri }) => {
+branch.subscribe(({ error, params }) => {
   if (error) {
     console.error("Error from Branch: " + error)
     return
@@ -11,6 +11,4 @@ branch.subscribe(({ error, params, uri }) => {
   console.info("Received link response from Branch")
 
   console.log("params: " + JSON.stringify(params))
-
-  console.log("URI: " + uri)
 })

--- a/examples/webview_example/src/App.js
+++ b/examples/webview_example/src/App.js
@@ -11,15 +11,11 @@ export default class App extends Component {
   navigator = null
 
   componentWillMount() {
-    this._unsubscribeFromBranch = branch.subscribe(({ error, params, uri }) => {
+    this._unsubscribeFromBranch = branch.subscribe(({ error, params }) => {
       if (error) {
         console.error("Error opening Branch link: " + error)
         return
       }
-
-      if (uri) console.log(uri + " opened via Branch")
-
-      if (!params) return
 
       console.log("Branch link params: " + JSON.stringify(params))
 


### PR DESCRIPTION
To conform with the rest of the Branch SDKs, particularly the underlying iOS and Android SDKs, the data model has been changed slightly.

This SDK alone adds a `uri` property in the `subscribe` callback. This was always the original deep link that opened the app, equivalent to the `~referring_link` (Branch) or `+non_branch_link` (non-Branch) parameter returned by the API. However, there was also a filter on the `~id` parameter, a unique identifier assigned to each click on a Branch link. If that was not present, `params` would always be null. In particular, for non-Branch links, there is no `~id` parameter. In that case, the `params` were not passed, and the `+non_branch_link` was unavailable. It was only available via the `uri` field.

This leads to some confusion at times. All unique and interesting information is in the `params` and the `error` field. The `uri` repeats information that was already present in the parameters returned by the native SDKs but was filtered out. And since this SDK has had a somewhat different data model from all the others, it has not always been in line with Branch's general documentation.

The filter on `~id` has been removed. Now `params` will never be null. In responses from certain API calls (e.g., initialization) it will always contain at least `+clicked_branch_link` and `+is_first_session`. For non-Branch links it will also contain a `+non_branch_link` field, which will always have the same value as the `uri` field. Behavior is unchanged when opening Branch links. The `uri` field will always be the same as the `~referring_link` field in the `params`. Now that the `uri` field is completely redundant, it may be removed in a future release (>= 3.0). It is not recommended to rely on it.

Also, populating the `uri` field in the native iOS layer required unnecessary state maintenance, a source of bugs. Now, on both platforms, rather than being set from the original link that opened the app, before being passed to Branch, it is taken from the `~referring_link` or `+non_branch_link` field, guaranteeing its redundancy. If neither is present, it may be null.

A separate docs PR will follow. 

This should help address #201.