### PR TITLE
Disable setDebug()

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -58,7 +58,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     private static WeakReference<Branch.BranchUniversalReferralInitListener> initListener = null;
 
     private static Activity mActivity = null;
-    private static Branch mBranch = null;
+    private static boolean mUseDebug = false;
 
     private AgingHash<String, BranchUniversalObject> mUniversalObjectMap = new AgingHash<>(AGING_HASH_TTL);
 
@@ -68,9 +68,12 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     public static void initSession(final Uri uri, Activity reactActivity) {
-        mBranch = Branch.getInstance(reactActivity.getApplicationContext());
+        Branch branch = Branch.getInstance(reactActivity.getApplicationContext());
+
+        if (mUseDebug) branch.setDebug();
+
         mActivity = reactActivity;
-        mBranch.initSession(new Branch.BranchReferralInitListener(){
+        branch.initSession(new Branch.BranchReferralInitListener(){
 
             private Activity mmActivity = null;
 
@@ -168,7 +171,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     public static void setDebug() {
-        mBranch.setDebug();
+        mUseDebug = true;
     }
 
     public RNBranchModule(ReactApplicationContext reactContext) {

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -167,6 +167,10 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         }.init(reactActivity), uri, reactActivity);
     }
 
+    public static void setDebug() {
+        mBranch.setDebug();
+    }
+
     public RNBranchModule(ReactApplicationContext reactContext) {
         super(reactContext);
         forwardInitSessionFinishedEventToReactNative(reactContext);

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -241,12 +241,6 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setDebug() {
-        Branch branch = Branch.getInstance();
-        branch.setDebug();
-    }
-
-    @ReactMethod
     public void getLatestReferringParams(Promise promise) {
         Branch branch = Branch.getInstance();
         promise.resolve(convertJsonToMap(branch.getLatestReferringParams()));

--- a/docs/setDebug.md
+++ b/docs/setDebug.md
@@ -1,0 +1,41 @@
+The `setDebug` method exists in the underlying native SDKs and the documentation
+for the react-native-branch SDK. Unfortunately, it is not possible to
+implement it in JavaScript immediately because the native methods must be called
+before initializing the native SDKs. Currently, the native SDKs are initialized
+before the JavaScript loads. By the time a React Native app calls `setDebug`,
+it is too late to call it. This is likely to change in a future release.
+
+For now, it is necessary to make the call directly in native code on both
+platforms.
+
+#### iOS
+
+##### Objective-C
+
+In AppDelegate.m, before calling `[RNBranch initSessionWithLaunchOptions:isReferrable:]`,
+call `[RNBranch setDebug]`.
+
+```Obj-C
+[RNBranch setDebug];
+[RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
+```
+
+##### Swift
+
+In AppDelegate.swift, before calling `RNBranch.initSession(launchOptions:, isReferrable:)`,
+call `RNBranch.setDebug()`.
+
+```Swift
+RNBranch.setDebug()
+RNBranch.initSession(launchOptions: launchOptions, isReferrable: true)
+```
+
+#### Android
+
+In your Activity source file, e.g. MainActivity.java, before calling `RNBranch.initSession()`,
+call `RNBranch.setDebug()`:
+
+```Java
+RNBranchModule.setDebug();
+RNBranchModule.initSession(getIntent().getData(), this);
+```

--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -14,5 +14,6 @@ extern NSString * const RNBranchLinkOpenedNotificationLinkPropertiesKey;
 + (BOOL)handleDeepLink:(NSURL *)url;
 + (BOOL)continueUserActivity:(NSUserActivity *)userActivity;
 + (void)useTestInstance;
++ (void)setDebug;
 
 @end

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -57,6 +57,11 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Class methods
 
++ (void)setDebug
+{
+    [branchInstance setDebug];
+}
+
 + (void)useTestInstance {
     branchInstance = [Branch getTestInstance];
 }

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -178,7 +178,7 @@ RCT_EXPORT_MODULE();
 
         reject(@"RNBranch::Error::BUONotFound", errorMessage, error);
     }
-    
+
     return universalObject;
 }
 
@@ -190,13 +190,6 @@ RCT_EXPORT_METHOD(
                   rejecter:(__unused RCTPromiseRejectBlock)reject
                   ) {
     resolve(initSessionWithLaunchOptionsResult ?: [NSNull null]);
-}
-
-#pragma mark setDebug
-RCT_EXPORT_METHOD(
-                  setDebug
-                  ) {
-    [branchInstance setDebug];
 }
 
 #pragma mark getLatestReferringParams

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ class Branch {
   }
 
   /*** RNBranch singleton methods ***/
-  setDebug = () => { throw "setDebug() is not supported in the RN SDK. For a solution in native code, please see https://rnbranch.app.link/hGj7E61EhD." }
+  setDebug = () => { throw 'setDebug() is not supported in the RN SDK. For a solution in native code, please see https://rnbranch.app.link/hGj7E61EhD' }
   getLatestReferringParams = RNBranch.getLatestReferringParams
   getFirstReferringParams = RNBranch.getFirstReferringParams
   setIdentity = (identity) => RNBranch.setIdentity(identity)

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ class Branch {
   }
 
   /*** RNBranch singleton methods ***/
-  setDebug = () => { throw "setDebug() is not supported in the RN SDK. For a solution in native code, please see https://github.com/BranchMetrics/react-native-branch-deep-linking/blob/master/docs/setDebug.md." }
+  setDebug = () => { throw "setDebug() is not supported in the RN SDK. For a solution in native code, please see https://rnbranch.app.link/hGj7E61EhD." }
   getLatestReferringParams = RNBranch.getLatestReferringParams
   getFirstReferringParams = RNBranch.getFirstReferringParams
   setIdentity = (identity) => RNBranch.setIdentity(identity)

--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ class Branch {
   }
 
   /*** RNBranch singleton methods ***/
-  setDebug = RNBranch.setDebug
+  setDebug = () => { throw "setDebug() is not supported in the RN SDK. For a solution in native code, please see https://github.com/BranchMetrics/react-native-branch-deep-linking/blob/master/docs/setDebug.md." }
   getLatestReferringParams = RNBranch.getLatestReferringParams
   getFirstReferringParams = RNBranch.getFirstReferringParams
   setIdentity = (identity) => RNBranch.setIdentity(identity)


### PR DESCRIPTION
This method is not supportable without a sizable refactoring because the underlying native call must be made before the native SDK initializes, which happens before the JS loads. It has been indicated in the documentation in the past, however. Simple native calls were added: `[RNBranch setDebug]` (iOS) and `RNBranch.setDebug()` (Android). A document was added with instructions for adding these calls to the native code. Now the JS `setDebug` method throws an exception rather than calling the native layer. The error message includes a link to this doc.

In a future release we may be able to offer the option to delay native SDK initialization until the JS has loaded and support a number of unsupportable features like this.

An overhaul of the documentation is part of the 2.0.0 release and is coming very soon.

Addresses #58.