### PR TITLE
Enable apple ad attribution tracking in React Native Apps

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -70,6 +70,7 @@ RCT_EXPORT_MODULE();
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable {
     if (!branchInstance) {
         branchInstance = [Branch getInstance];
+	[branchInstance delayInitToCheckForSearchAds];
     }
 
     [branchInstance initSessionWithLaunchOptions:launchOptions isReferrable:isReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {


### PR DESCRIPTION
RNBranch doesn't call delayInitToCheckForSearchAds, so adding this as it is the wrapper we use in our react native app. 

Doesn't look like this is in the issue tracker, so wanted to add this functionality in.

#Test Plan
Ran NPM Test and fastlane iOS tests to verify no failures.