### PR TITLE
Added some wrapper methods for iOS

### DIFF
--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -1,19 +1,25 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 
-extern NSString * const RNBranchLinkOpenedNotification;
-extern NSString * const RNBranchLinkOpenedNotificationErrorKey;
-extern NSString * const RNBranchLinkOpenedNotificationParamsKey;
-extern NSString * const RNBranchLinkOpenedNotificationUriKey;
-extern NSString * const RNBranchLinkOpenedNotificationBranchUniversalObjectKey;
-extern NSString * const RNBranchLinkOpenedNotificationLinkPropertiesKey;
+extern NSString * _Nonnull const RNBranchLinkOpenedNotification;
+extern NSString * _Nonnull const RNBranchLinkOpenedNotificationErrorKey;
+extern NSString * _Nonnull const RNBranchLinkOpenedNotificationParamsKey;
+extern NSString * _Nonnull const RNBranchLinkOpenedNotificationUriKey;
+extern NSString * _Nonnull const RNBranchLinkOpenedNotificationBranchUniversalObjectKey;
+extern NSString * _Nonnull const RNBranchLinkOpenedNotificationLinkPropertiesKey;
 
 @interface RNBranch : NSObject <RCTBridgeModule>
 
-+ (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable;
-+ (BOOL)handleDeepLink:(NSURL *)url;
-+ (BOOL)continueUserActivity:(NSUserActivity *)userActivity;
++ (void)initSessionWithLaunchOptions:(NSDictionary * _Nullable)launchOptions isReferrable:(BOOL)isReferrable;
++ (BOOL)handleDeepLink:(NSURL * _Nonnull)url;
++ (BOOL)continueUserActivity:(NSUserActivity * _Nonnull)userActivity;
+
+// Must be called before any other static method below
 + (void)useTestInstance;
+
 + (void)setDebug;
++ (void)delayInitToCheckForSearchAds;
++ (void)setAppleSearchAdsDebugMode;
++ (void)setRequestMetadataKey:(NSString * _Nonnull)key value:(NSObject * _Nonnull)value;
 
 @end

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -57,9 +57,35 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - Class methods
 
++ (void)setupInstance
+{
+    if (!branchInstance) {
+        branchInstance = [Branch getInstance];
+    }
+}
+
 + (void)setDebug
 {
+    [self setupInstance];
     [branchInstance setDebug];
+}
+
++ (void)delayInitToCheckForSearchAds
+{
+    [self setupInstance];
+    [branchInstance delayInitToCheckForSearchAds];
+}
+
++ (void)setAppleSearchAdsDebugMode
+{
+    [self setupInstance];
+    [branchInstance setAppleSearchAdsDebugMode];
+}
+
++ (void)setRequestMetadataKey:(NSString *)key value:(NSObject *)value
+{
+    [self setupInstance];
+    [branchInstance setRequestMetadataKey:key value:value];
 }
 
 + (void)useTestInstance {
@@ -68,9 +94,7 @@ RCT_EXPORT_MODULE();
 
 //Called by AppDelegate.m -- stores initSession result in static variables and posts RNBranchLinkOpened event that's captured by the RNBranch instance to emit it to React Native
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable {
-    if (!branchInstance) {
-        branchInstance = [Branch getInstance];
-    }
+    [self setupInstance];
 
     [branchInstance initSessionWithLaunchOptions:launchOptions isReferrable:isReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
         NSMutableDictionary *result = [NSMutableDictionary dictionary];


### PR DESCRIPTION
Added

- `[RNBranch setRequestMetadataKey:value:]`, particularly for Mixpanel integration.
- `[RNBranch delayInitToCheckForSearchAds]`
- `[RNBranch setAppleSearchAdsDebugMode]`

These are wrappers around the underlying Branch SDK calls, but since the RNBranch object manages its own Branch instance (controlled by `[RNBranch useTestInstance]`), this simplifies matters for native callers. Instead of adding `#import <Branch/Branch.h>` and, e.g.:

```Obj-C
#ifdef DEBUG
    [[Branch getTestInstance] delayInitToCheckForSearchAds];
#else
    [[Branch getInstance] delayInitToCheckForSearchAds];
#endif
    [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
```

Now you can just add:

```Obj-C
    [RNBranch delayInitToCheckForSearchAds];
    [RNBranch initSessionWithLaunchOptions:launchOptions isReferrable:YES];
```

This will work properly whether `[RNBranch useTestInstance]` is called or not.

This is similar to what was done for setDebug.

The last two methods are only present on iOS. If needed, an `RNBranch.setRequestMetadata()` method could be added, but since `Branch.getInstance().setRequestMetadata()` doesn't have to be called before initialization, it's not clear if it's necessary.