### PR TITLE
Deprecated [RNBranch handleDeepLink:]

### DIFF
--- a/examples/testbed_native_ios/testbed_native_ios/AppDelegate.m
+++ b/examples/testbed_native_ios/testbed_native_ios/AppDelegate.m
@@ -27,7 +27,7 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-    if (![RNBranch handleDeepLink:url]) {
+    if (![RNBranch.branch application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
         // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
     }
     return YES;

--- a/examples/testbed_simple/ios/testbed_simple/AppDelegate.m
+++ b/examples/testbed_simple/ios/testbed_simple/AppDelegate.m
@@ -43,7 +43,7 @@
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {
-  if (![RNBranch handleDeepLink:url]) {
+  if (![RNBranch.branch application:application openURL:url sourceApplication:sourceApplication annotation:annotation]) {
     // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
   }
   return YES;

--- a/examples/webview_example/ios/webview_example/AppDelegate.m
+++ b/examples/webview_example/ios/webview_example/AppDelegate.m
@@ -44,7 +44,7 @@
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<UIApplicationOpenURLOptionsKey,id> *)options
 {
-  return [RNBranch handleDeepLink:url] || [[UIApplication sharedApplication] openURL:url];
+  return [RNBranch.branch application:app openURL:url options:options] || [[UIApplication sharedApplication] openURL:url];
 }
 
 - (BOOL)application:(UIApplication *)app continueUserActivity:(nonnull NSUserActivity *)userActivity restorationHandler:(nonnull void (^)(NSArray * _Nullable))restorationHandler

--- a/examples/webview_example_native_ios/WebViewExample/AppDelegate.swift
+++ b/examples/webview_example_native_ios/WebViewExample/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
-        return RNBranch.handleDeepLink(url)
+        return RNBranch.branch.application(app, open: url, options: options)
     }
     
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([Any]?) -> Void) -> Bool {

--- a/ios/RNBranch.h
+++ b/ios/RNBranch.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTBridgeModule.h>
 
+#import <Branch/Branch.h>
+
 extern NSString * _Nonnull const RNBranchLinkOpenedNotification;
 extern NSString * _Nonnull const RNBranchLinkOpenedNotificationErrorKey;
 extern NSString * _Nonnull const RNBranchLinkOpenedNotificationParamsKey;
@@ -8,12 +10,13 @@ extern NSString * _Nonnull const RNBranchLinkOpenedNotificationUriKey;
 extern NSString * _Nonnull const RNBranchLinkOpenedNotificationBranchUniversalObjectKey;
 extern NSString * _Nonnull const RNBranchLinkOpenedNotificationLinkPropertiesKey;
 
-@class Branch;
 
 @interface RNBranch : NSObject <RCTBridgeModule>
 
+@property (class, readonly, nonnull) Branch *branch;
+
 + (void)initSessionWithLaunchOptions:(NSDictionary * _Nullable)launchOptions isReferrable:(BOOL)isReferrable;
-+ (BOOL)handleDeepLink:(NSURL * _Nonnull)url;
++ (BOOL)handleDeepLink:(NSURL * _Nonnull)url __deprecated_msg("Please use [RNBranch.branch application:openURL:options] or [RNBranch.branch application:openURL:sourceApplication:annotation:] instead.");
 + (BOOL)continueUserActivity:(NSUserActivity * _Nonnull)userActivity;
 
 // Must be called before any other static method below
@@ -23,7 +26,5 @@ extern NSString * _Nonnull const RNBranchLinkOpenedNotificationLinkPropertiesKey
 + (void)delayInitToCheckForSearchAds;
 + (void)setAppleSearchAdsDebugMode;
 + (void)setRequestMetadataKey:(NSString * _Nonnull)key value:(NSObject * _Nonnull)value;
-
-+ (Branch * _Nonnull)branch;
 
 @end

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -41,27 +41,29 @@ RCT_EXPORT_MODULE();
 
 + (Branch *)branch
 {
-    static Branch *instance;
-    static dispatch_once_t once = 0;
-    dispatch_once(&once, ^{
-        RNBranchConfig *config = RNBranchConfig.instance;
+    @synchronized(self.class) {
+        static Branch *instance;
+        static dispatch_once_t once = 0;
+        dispatch_once(&once, ^{
+            RNBranchConfig *config = RNBranchConfig.instance;
 
-        // YES if either [RNBranch useTestInstance] was called or useTestInstance: true is present in branch.json.
-        BOOL usingTestInstance = useTestInstance || config.useTestInstance;
-        NSString *key = usingTestInstance ? config.testKey : config.liveKey;
+            // YES if either [RNBranch useTestInstance] was called or useTestInstance: true is present in branch.json.
+            BOOL usingTestInstance = useTestInstance || config.useTestInstance;
+            NSString *key = usingTestInstance ? config.testKey : config.liveKey;
 
-        if (key) {
-            // Override the Info.plist if these are present.
-            RCTLog(@"Using Branch key %@ from branch.json", key);
-            instance = [Branch getInstance: key];
-        }
-        else {
-            instance = usingTestInstance ? [Branch getTestInstance] : [Branch getInstance];
-        }
-
-        [self setupBranchInstance:instance];
-    });
-    return instance;
+            if (key) {
+                // Override the Info.plist if these are present.
+                RCTLog(@"Using Branch key %@ from branch.json", key);
+                instance = [Branch getInstance: key];
+            }
+            else {
+                instance = usingTestInstance ? [Branch getTestInstance] : [Branch getInstance];
+            }
+            
+            [self setupBranchInstance:instance];
+        });
+        return instance;
+    }
 }
 
 + (void)setupBranchInstance:(Branch *)instance


### PR DESCRIPTION
- Introduced `RNBranch.branch` class property to expose the Branch instance used.
- Added a deprecation message to `handleDeepLink:`
- Converted examples to use the newer methods on the Branch instance.