### PR TITLE
More settings in branch.json

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchConfig.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchConfig.java
@@ -73,6 +73,20 @@ public class RNBranchConfig {
     }
 
     @Nullable
+    public String getBranchKey() {
+        if (mConfiguration == null) return null;
+
+        try {
+            if (!mConfiguration.has("branchKey")) return null;
+            return mConfiguration.getString("branchKey");
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
     public String getLiveKey() {
         if (mConfiguration == null) return null;
 

--- a/android/src/main/java/io/branch/rnbranch/RNBranchConfig.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchConfig.java
@@ -50,6 +50,7 @@ public class RNBranchConfig {
         if (mConfiguration == null) return null;
 
         try {
+            if (!mConfiguration.has(key)) return null;
             return mConfiguration.get(key);
         }
         catch (JSONException exception) {
@@ -62,7 +63,49 @@ public class RNBranchConfig {
         if (mConfiguration == null) return false;
 
         try {
+            if (!mConfiguration.has("debugMode")) return false;
             return mConfiguration.getBoolean("debugMode");
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return false;
+        }
+    }
+
+    @Nullable
+    public String getLiveKey() {
+        if (mConfiguration == null) return null;
+
+        try {
+            if (!mConfiguration.has("liveKey")) return null;
+            return mConfiguration.getString("liveKey");
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return null;
+        }
+    }
+
+    @Nullable
+    public String getTestKey() {
+        if (mConfiguration == null) return null;
+
+        try {
+            if (!mConfiguration.has("testKey")) return null;
+            return mConfiguration.getString("testKey");
+        }
+        catch (JSONException exception) {
+            Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());
+            return null;
+        }
+    }
+
+    public boolean getUseTestInstance() {
+        if (mConfiguration == null) return false;
+
+        try {
+            if (!mConfiguration.has("useTestInstance")) return false;
+            return mConfiguration.getBoolean("useTestInstance");
         }
         catch (JSONException exception) {
             Log.e(TAG, "Error parsing branch.json: " + exception.getMessage());

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -442,7 +442,9 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
     private static Branch setupBranch(Context context) {
         RNBranchConfig config = new RNBranchConfig(context);
-        String branchKey = config.getUseTestInstance() ? config.getTestKey() : config.getLiveKey();
+        String branchKey = config.getBranchKey();
+        if (branchKey == null) branchKey = config.getUseTestInstance() ? config.getTestKey() : config.getLiveKey();
+
         /*
          * This differs a little from iOS. If you add "useTestInstance": true to branch.json but
          * don't add the testKey, on iOS, it will use the test key from the Info.plist if configured.

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -68,15 +68,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     public static void initSession(final Uri uri, Activity reactActivity) {
-        Branch branch = Branch.getInstance(reactActivity.getApplicationContext());
-
-        RNBranchConfig config = new RNBranchConfig(reactActivity);
-        if (config.getDebugMode()) {
-            Log.d(REACT_CLASS, "debugMode true in branch.json. calling setDebug().");
-            branch.setDebug();
-        }
-
-        if (mUseDebug) branch.setDebug();
+        Branch branch = setupBranch(reactActivity.getApplicationContext());
 
         mActivity = reactActivity;
         branch.initSession(new Branch.BranchReferralInitListener(){
@@ -446,6 +438,24 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
         }
 
         return linkProperties;
+    }
+
+    private static Branch setupBranch(Context context) {
+        RNBranchConfig config = new RNBranchConfig(context);
+        String branchKey = config.getUseTestInstance() ? config.getTestKey() : config.getLiveKey();
+        /*
+         * This differs a little from iOS. If you add "useTestInstance": true to branch.json but
+         * don't add the testKey, on iOS, it will use the test key from the Info.plist if configured.
+         * On Android, useTestInstance in branch.json will be ignored unless testKey is present. If
+         * testKey is not specified in branch.json, it's necessary to add io.branch.sdk.TestMode to
+         * the Android manifest to use the test instance. It's not clear if there's a programmatic
+         * way to select the test key without specifying the key explicitly.
+         */
+        Branch branch = branchKey != null ? Branch.getInstance(context, branchKey) : Branch.getInstance(context);
+
+        if (mUseDebug || config.getDebugMode()) branch.setDebug();
+
+        return branch;
     }
 
     private BranchUniversalObject findUniversalObjectOrReject(final String ident, final Promise promise) {

--- a/branch.example.json
+++ b/branch.example.json
@@ -1,3 +1,8 @@
 {
-    "debugMode": true
+    "debugMode": true,
+    "liveKey": "key_live_xxxx",
+    "testKey": "key_test_yyyy",
+    "useTestInstance": true,
+    "delayInitToCheckForSearchAds": true,
+    "appleSearchAdsDebugMode": true
 }

--- a/docs/branch.json.md
+++ b/docs/branch.json.md
@@ -12,7 +12,7 @@ certain methods in the native SDKs that must be called before the native SDK ini
 ## Add the files to your project
 
 Be sure to commit `branch.json` and `branch.debug.json` to source control after adding
-them to your project.
+them to your project (after running `react-native link`).
 
 ### Using react-native link
 
@@ -74,6 +74,12 @@ of `branch.json`.
 |key|description|type|
 |---|---|---|
 |debugMode|If true, `setDebug` will be called in the native SDK, enabling testing of install events.|Boolean|
+|branchKey|If set, the specified key overrides all other settings, including the Info.plist, AndroidManifest.xml and the liveKey and testKey settings here.|String|
+|liveKey|If branchKey is not set and useTestInstance is false or absent, this key will be used to override the keys from the Info.plist and AndroidManifest.xml|String|
+|testKey|If branchKey is not set and useTestInstance is true, this key will be used to override the keys from the Info.plist and AndroidManifest.xml|String|
+|useTestInstance|If branchKey is not set and useTestInstance is true, the testKey from branch.json will be used if present. If branchKey and testKey are not set: On iOS, the test key from the Info.plist will be used, if present. On Android, the io.branch.sdk.TestMode metadata key will determine which instance is used.|Boolean|
+|appleSearchAdsDebugMode|If true, `setAppleSearchAdsDebugMode` will be called on the iOS Branch instance. Ignored on Android.|Boolean|
+|delayInitToCheckForSearchAds|If true, `delayInitToCheckForSearchAds` will be called on the iOS Branch instance. Ignored on Android.|Boolean|
 
 ## Example
 
@@ -81,6 +87,11 @@ See [branch.example.json](https://github.com/BranchMetrics/react-native-branch-d
 
 ```json
 {
-  "debugMode": true
+    "debugMode": true,
+    "liveKey": "key_live_xxxx",
+    "testKey": "key_test_yyyy",
+    "useTestInstance": true,
+    "delayInitToCheckForSearchAds": true,
+    "appleSearchAdsDebugMode": true
 }
 ```

--- a/examples/testbed_simple/branch.debug.json
+++ b/examples/testbed_simple/branch.debug.json
@@ -1,3 +1,6 @@
 {
-    "debugMode": true
+    "debugMode": true,
+    "branchKey": "key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc",
+    "delayInitToCheckForSearchAds": true,
+    "appleSearchAdsDebugMode": true
 }

--- a/examples/testbed_simple/branch.json
+++ b/examples/testbed_simple/branch.json
@@ -1,3 +1,3 @@
 {
-    "debugMode": false
+    "branchKey": "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv",
 }

--- a/examples/webview_example/branch.debug.json
+++ b/examples/webview_example/branch.debug.json
@@ -1,3 +1,6 @@
 {
-    "debugMode": true
+  "debugMode": true,
+  "branchKey": "key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc",
+  "delayInitToCheckForSearchAds": true,
+  "appleSearchAdsDebugMode": true
 }

--- a/examples/webview_example/branch.debug.json
+++ b/examples/webview_example/branch.debug.json
@@ -1,6 +1,6 @@
 {
-  "debugMode": true,
-  "branchKey": "key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc",
-  "delayInitToCheckForSearchAds": true,
-  "appleSearchAdsDebugMode": true
+    "debugMode": true,
+    "branchKey": "key_test_hdcBLUy1xZ1JD0tKg7qrLcgirFmPPVJc",
+    "delayInitToCheckForSearchAds": true,
+    "appleSearchAdsDebugMode": true
 }

--- a/examples/webview_example/branch.json
+++ b/examples/webview_example/branch.json
@@ -1,3 +1,3 @@
 {
-  "branchKey": "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv",
+    "branchKey": "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv",
 }

--- a/examples/webview_example/branch.json
+++ b/examples/webview_example/branch.json
@@ -1,3 +1,3 @@
 {
-    "debugMode": false
+  "branchKey": "key_live_feebgAAhbH9Tv85H5wLQhpdaefiZv5Dv",
 }

--- a/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
+++ b/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -21,6 +22,7 @@
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		140ED2AC1D01E1AD002B40FF /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
+		1F3D2604C5894FABA505C1E6 /* branch.json in Resources */ = {isa = PBXBuildFile; fileRef = 88E5A73955AF4F4791A0EC13 /* branch.json */; };
 		2D02E4BC1E0B4A80006451C7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		2D02E4BD1E0B4A84006451C7 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		2D02E4BF1E0B4AB3006451C7 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
@@ -34,10 +36,9 @@
 		2D02E4C91E0B4AEC006451C7 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3DAD3EA31DF850E9000B6D8A /* libReact.a */; };
 		2DCD954D1E0B4F2C00145EB5 /* webview_exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* webview_exampleTests.m */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
-		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		745AD64334D4458CACDF7DE5 /* libreact-native-branch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E804E42122448BFA4A8C75D /* libreact-native-branch.a */; };
-		1F3D2604C5894FABA505C1E6 /* branch.json in Resources */ = {isa = PBXBuildFile; fileRef = 88E5A73955AF4F4791A0EC13 /* branch.json */; };
 		5F3AFDA5B9C4498C85B0E9C6 /* branch.debug.json in Resources */ = {isa = PBXBuildFile; fileRef = BDB6890F28C04D8DABC9ADDC /* branch.debug.json */; };
+		745AD64334D4458CACDF7DE5 /* libreact-native-branch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E804E42122448BFA4A8C75D /* libreact-native-branch.a */; };
+		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -223,6 +224,13 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
+		7BBA71391EFB170500E4FAE6 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C92DDC70F46442208FFC1E50 /* RNBranch.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = B3A3CC361C5B0A070016AC52;
+			remoteInfo = RNBranch;
+		};
 		832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
@@ -254,14 +262,14 @@
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* webview_example-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "webview_example-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* webview_example-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "webview_example-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3E804E42122448BFA4A8C75D /* libreact-native-branch.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libreact-native-branch.a"; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		7BC69F431EA12D87000B04CE /* webview_example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = webview_example.entitlements; path = webview_example/webview_example.entitlements; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		C92DDC70F46442208FFC1E50 /* RNBranch.xcodeproj */ = {isa = PBXFileReference; name = "RNBranch.xcodeproj"; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
-		3E804E42122448BFA4A8C75D /* libreact-native-branch.a */ = {isa = PBXFileReference; name = "libreact-native-branch.a"; path = "libreact-native-branch.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
-		88E5A73955AF4F4791A0EC13 /* branch.json */ = {isa = PBXFileReference; name = "branch.json"; path = "../branch.json"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
-		BDB6890F28C04D8DABC9ADDC /* branch.debug.json */ = {isa = PBXFileReference; name = "branch.debug.json"; path = "../branch.debug.json"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		88E5A73955AF4F4791A0EC13 /* branch.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = branch.json; path = ../branch.json; sourceTree = "<group>"; };
+		BDB6890F28C04D8DABC9ADDC /* branch.debug.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = branch.debug.json; path = ../branch.debug.json; sourceTree = "<group>"; };
+		C92DDC70F46442208FFC1E50 /* RNBranch.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNBranch.xcodeproj; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -440,6 +448,14 @@
 			children = (
 				78C398B91ACF4ADC00677621 /* libRCTLinking.a */,
 				3DAD3E881DF850E9000B6D8A /* libRCTLinking-tvOS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7BBA711D1EFB170500E4FAE6 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7BBA713A1EFB170500E4FAE6 /* libreact-native-branch.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -659,6 +675,10 @@
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
+				{
+					ProductGroup = 7BBA711D1EFB170500E4FAE6 /* Products */;
+					ProjectRef = C92DDC70F46442208FFC1E50 /* RNBranch.xcodeproj */;
+				},
 			);
 			projectRoot = "";
 			targets = (
@@ -839,11 +859,11 @@
 			remoteRef = 78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		7B730F9E1EF45DBC0084C126 /* libreact-native-branch.a */ = {
+		7BBA713A1EFB170500E4FAE6 /* libreact-native-branch.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = "libreact-native-branch.a";
-			remoteRef = 7B730F9D1EF45DBC0084C126 /* PBXContainerItemProxy */;
+			remoteRef = 7BBA71391EFB170500E4FAE6 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		832341B51AAA6A8300B99B32 /* libRCTText.a */ = {

--- a/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
+++ b/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
@@ -5,7 +5,6 @@
 	};
 	objectVersion = 46;
 	objects = {
-
 /* Begin PBXBuildFile section */
 		00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302AC1ABCB8CE00DB3ED1 /* libRCTActionSheet.a */; };
 		00C302E71ABCBA2D00DB3ED1 /* libRCTGeolocation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 00C302BA1ABCB90400DB3ED1 /* libRCTGeolocation.a */; };
@@ -36,9 +35,9 @@
 		2DCD954D1E0B4F2C00145EB5 /* webview_exampleTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* webview_exampleTests.m */; };
 		5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E9157331DD0AC6500FF2AA8 /* libRCTAnimation.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
-		984AD350ABCF44648D313C26 /* branch.debug.json in Resources */ = {isa = PBXBuildFile; fileRef = DD8512B7E14B43B39B85AC31 /* branch.debug.json */; };
-		B8A8112C73234AED891FA1A2 /* libreact-native-branch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CC509C91D507497F8165A349 /* libreact-native-branch.a */; };
-		BEDB4691F7BF4FA48FC081DD /* branch.json in Resources */ = {isa = PBXBuildFile; fileRef = 3415DB24CA1C4104B4EF2DE8 /* branch.json */; };
+		745AD64334D4458CACDF7DE5 /* libreact-native-branch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E804E42122448BFA4A8C75D /* libreact-native-branch.a */; };
+		1F3D2604C5894FABA505C1E6 /* branch.json in Resources */ = {isa = PBXBuildFile; fileRef = 88E5A73955AF4F4791A0EC13 /* branch.json */; };
+		5F3AFDA5B9C4498C85B0E9C6 /* branch.debug.json in Resources */ = {isa = PBXBuildFile; fileRef = BDB6890F28C04D8DABC9ADDC /* branch.debug.json */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,13 +223,6 @@
 			remoteGlobalIDString = 134814201AA4EA6300B7C361;
 			remoteInfo = RCTLinking;
 		};
-		7B730F9D1EF45DBC0084C126 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 7C6682BF513D49AF83D3AA9F /* RNBranch.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = B3A3CC361C5B0A070016AC52;
-			remoteInfo = RNBranch;
-		};
 		832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */;
@@ -262,14 +254,14 @@
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
 		2D02E47B1E0B4A5D006451C7 /* webview_example-tvOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "webview_example-tvOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2D02E4901E0B4A5D006451C7 /* webview_example-tvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "webview_example-tvOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		3415DB24CA1C4104B4EF2DE8 /* branch.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = branch.json; path = ../branch.json; sourceTree = "<group>"; };
 		5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTAnimation.xcodeproj; path = "../node_modules/react-native/Libraries/NativeAnimation/RCTAnimation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		7BC69F431EA12D87000B04CE /* webview_example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = webview_example.entitlements; path = webview_example/webview_example.entitlements; sourceTree = "<group>"; };
-		7C6682BF513D49AF83D3AA9F /* RNBranch.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNBranch.xcodeproj; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
-		CC509C91D507497F8165A349 /* libreact-native-branch.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libreact-native-branch.a"; sourceTree = "<group>"; };
-		DD8512B7E14B43B39B85AC31 /* branch.debug.json */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = branch.debug.json; path = ../branch.debug.json; sourceTree = "<group>"; };
+		C92DDC70F46442208FFC1E50 /* RNBranch.xcodeproj */ = {isa = PBXFileReference; name = "RNBranch.xcodeproj"; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = wrapper.pb-project; explicitFileType = undefined; includeInIndex = 0; };
+		3E804E42122448BFA4A8C75D /* libreact-native-branch.a */ = {isa = PBXFileReference; name = "libreact-native-branch.a"; path = "libreact-native-branch.a"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = archive.ar; explicitFileType = undefined; includeInIndex = 0; };
+		88E5A73955AF4F4791A0EC13 /* branch.json */ = {isa = PBXFileReference; name = "branch.json"; path = "../branch.json"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
+		BDB6890F28C04D8DABC9ADDC /* branch.debug.json */ = {isa = PBXFileReference; name = "branch.debug.json"; path = "../branch.debug.json"; sourceTree = "<group>"; fileEncoding = undefined; lastKnownFileType = unknown; explicitFileType = undefined; includeInIndex = 0; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -296,7 +288,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
-				B8A8112C73234AED891FA1A2 /* libreact-native-branch.a in Frameworks */,
+				745AD64334D4458CACDF7DE5 /* libreact-native-branch.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -413,8 +405,8 @@
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				13B07FB11A68108700A75B9A /* LaunchScreen.xib */,
 				13B07FB71A68108700A75B9A /* main.m */,
-				3415DB24CA1C4104B4EF2DE8 /* branch.json */,
-				DD8512B7E14B43B39B85AC31 /* branch.debug.json */,
+				88E5A73955AF4F4791A0EC13 /* branch.json */,
+				BDB6890F28C04D8DABC9ADDC /* branch.debug.json */,
 			);
 			name = webview_example;
 			sourceTree = "<group>";
@@ -452,14 +444,6 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		7B730F811EF45DBB0084C126 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				7B730F9E1EF45DBC0084C126 /* libreact-native-branch.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
@@ -474,7 +458,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
-				7C6682BF513D49AF83D3AA9F /* RNBranch.xcodeproj */,
+				C92DDC70F46442208FFC1E50 /* RNBranch.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -674,10 +658,6 @@
 				{
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
-				},
-				{
-					ProductGroup = 7B730F811EF45DBB0084C126 /* Products */;
-					ProjectRef = 7C6682BF513D49AF83D3AA9F /* RNBranch.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -889,8 +869,8 @@
 			files = (
 				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
 				13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */,
-				BEDB4691F7BF4FA48FC081DD /* branch.json in Resources */,
-				984AD350ABCF44648D313C26 /* branch.debug.json in Resources */,
+				1F3D2604C5894FABA505C1E6 /* branch.json in Resources */,
+				5F3AFDA5B9C4498C85B0E9C6 /* branch.debug.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -75,6 +75,9 @@ RCT_EXPORT_MODULE();
     if (config.delayInitToCheckForSearchAds) {
         [instance delayInitToCheckForSearchAds];
     }
+    if (config.appleSearchAdsDebugMode) {
+        [instance setAppleSearchAdsDebugMode];
+    }
 }
 
 - (NSDictionary<NSString *, NSString *> *)constantsToExport {

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -49,11 +49,10 @@ RCT_EXPORT_MODULE();
 
             // YES if either [RNBranch useTestInstance] was called or useTestInstance: true is present in branch.json.
             BOOL usingTestInstance = useTestInstance || config.useTestInstance;
-            NSString *key = usingTestInstance ? config.testKey : config.liveKey;
+            NSString *key = config.branchKey ?: usingTestInstance ? config.testKey : config.liveKey;
 
             if (key) {
                 // Override the Info.plist if these are present.
-                RCTLog(@"Using Branch key %@ from branch.json", key);
                 instance = [Branch getInstance: key];
             }
             else {

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -72,6 +72,9 @@ RCT_EXPORT_MODULE();
     if (config.debugMode) {
         [instance setDebug];
     }
+    if (config.delayInitToCheckForSearchAds) {
+        [instance delayInitToCheckForSearchAds];
+    }
 }
 
 - (NSDictionary<NSString *, NSString *> *)constantsToExport {

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -41,7 +41,7 @@ RCT_EXPORT_MODULE();
 
 + (Branch *)branch
 {
-    @synchronized(self.class) {
+    @synchronized(self) {
         static Branch *instance;
         static dispatch_once_t once = 0;
         dispatch_once(&once, ^{

--- a/ios/RNBranchConfig.h
+++ b/ios/RNBranchConfig.h
@@ -13,6 +13,7 @@ extern NSString * _Nonnull const RNBranchConfigLiveKeyOption;
 extern NSString * _Nonnull const RNBranchConfigTestKeyOption;
 extern NSString * _Nonnull const RNBranchConfigUseTestInstanceOption;
 extern NSString * _Nonnull const RNBranchConfigDelayInitToCheckForSearchAdsOption;
+extern NSString * _Nonnull const RNBranchConfigAppleSearchAdsDebugModeOption;
 
 @interface RNBranchConfig : NSObject
 
@@ -23,6 +24,7 @@ extern NSString * _Nonnull const RNBranchConfigDelayInitToCheckForSearchAdsOptio
 @property (nonatomic, readonly, nullable) NSString *testKey;
 @property (nonatomic, readonly) BOOL useTestInstance;
 @property (nonatomic, readonly) BOOL delayInitToCheckForSearchAds;
+@property (nonatomic, readonly) BOOL appleSearchAdsDebugMode;
 
 - (nullable id)objectForKey:(NSString * _Nonnull)key;
 - (nullable id)objectForKeyedSubscript:(NSString * _Nonnull)key;

--- a/ios/RNBranchConfig.h
+++ b/ios/RNBranchConfig.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 extern NSString * _Nonnull const RNBranchConfigDebugModeOption;
+extern NSString * _Nonnull const RNBranchConfigBranchKeyOption;
 extern NSString * _Nonnull const RNBranchConfigLiveKeyOption;
 extern NSString * _Nonnull const RNBranchConfigTestKeyOption;
 extern NSString * _Nonnull const RNBranchConfigUseTestInstanceOption;
@@ -20,6 +21,7 @@ extern NSString * _Nonnull const RNBranchConfigAppleSearchAdsDebugModeOption;
 @property (class, readonly, nonnull) RNBranchConfig *instance;
 @property (nonatomic, readonly, nullable) NSURL *configFileURL;
 @property (nonatomic, readonly) BOOL debugMode;
+@property (nonatomic, readonly, nullable) NSString *branchKey;
 @property (nonatomic, readonly, nullable) NSString *liveKey;
 @property (nonatomic, readonly, nullable) NSString *testKey;
 @property (nonatomic, readonly) BOOL useTestInstance;

--- a/ios/RNBranchConfig.h
+++ b/ios/RNBranchConfig.h
@@ -15,6 +15,7 @@ extern NSString * _Nonnull const RNBranchConfigUseTestInstanceOption;
 
 @interface RNBranchConfig : NSObject
 
+@property (class, readonly, nonnull) RNBranchConfig *instance;
 @property (nonatomic, readonly, nullable) NSURL *configFileURL;
 @property (nonatomic, readonly) BOOL debugMode;
 @property (nonatomic, readonly, nullable) NSString *liveKey;
@@ -23,7 +24,5 @@ extern NSString * _Nonnull const RNBranchConfigUseTestInstanceOption;
 
 - (nullable id)objectForKey:(NSString * _Nonnull)key;
 - (nullable id)objectForKeyedSubscript:(NSString * _Nonnull)key;
-
-+ (RNBranchConfig * _Nonnull)instance;
 
 @end

--- a/ios/RNBranchConfig.h
+++ b/ios/RNBranchConfig.h
@@ -12,6 +12,7 @@ extern NSString * _Nonnull const RNBranchConfigDebugModeOption;
 extern NSString * _Nonnull const RNBranchConfigLiveKeyOption;
 extern NSString * _Nonnull const RNBranchConfigTestKeyOption;
 extern NSString * _Nonnull const RNBranchConfigUseTestInstanceOption;
+extern NSString * _Nonnull const RNBranchConfigDelayInitToCheckForSearchAdsOption;
 
 @interface RNBranchConfig : NSObject
 
@@ -21,6 +22,7 @@ extern NSString * _Nonnull const RNBranchConfigUseTestInstanceOption;
 @property (nonatomic, readonly, nullable) NSString *liveKey;
 @property (nonatomic, readonly, nullable) NSString *testKey;
 @property (nonatomic, readonly) BOOL useTestInstance;
+@property (nonatomic, readonly) BOOL delayInitToCheckForSearchAds;
 
 - (nullable id)objectForKey:(NSString * _Nonnull)key;
 - (nullable id)objectForKeyedSubscript:(NSString * _Nonnull)key;

--- a/ios/RNBranchConfig.m
+++ b/ios/RNBranchConfig.m
@@ -14,6 +14,7 @@ NSString * _Nonnull const RNBranchConfigDebugModeOption = @"debugMode";
 NSString * _Nonnull const RNBranchConfigLiveKeyOption = @"liveKey";
 NSString * _Nonnull const RNBranchConfigTestKeyOption = @"testKey";
 NSString * _Nonnull const RNBranchConfigUseTestInstanceOption = @"useTestInstance";
+NSString * _Nonnull const RNBranchConfigDelayInitToCheckForSearchAdsOption = @"delayInitToCheckForSearchAds";
 
 @interface RNBranchConfig()
 @property (nonatomic) NSDictionary *configuration;
@@ -112,6 +113,12 @@ NSString * _Nonnull const RNBranchConfigUseTestInstanceOption = @"useTestInstanc
 - (BOOL)useTestInstance
 {
     NSNumber *number = self[RNBranchConfigUseTestInstanceOption];
+    return number.boolValue;
+}
+
+- (BOOL)delayInitToCheckForSearchAds
+{
+    NSNumber *number = self[RNBranchConfigDelayInitToCheckForSearchAdsOption];
     return number.boolValue;
 }
 

--- a/ios/RNBranchConfig.m
+++ b/ios/RNBranchConfig.m
@@ -11,6 +11,7 @@
 #import "RNBranchConfig.h"
 
 NSString * _Nonnull const RNBranchConfigDebugModeOption = @"debugMode";
+NSString * _Nonnull const RNBranchConfigBranchKeyOption = @"branchKey";
 NSString * _Nonnull const RNBranchConfigLiveKeyOption = @"liveKey";
 NSString * _Nonnull const RNBranchConfigTestKeyOption = @"testKey";
 NSString * _Nonnull const RNBranchConfigUseTestInstanceOption = @"useTestInstance";
@@ -127,6 +128,11 @@ NSString * _Nonnull const RNBranchConfigAppleSearchAdsDebugModeOption = @"appleS
 {
     NSNumber *number = self[RNBranchConfigAppleSearchAdsDebugModeOption];
     return number.boolValue;
+}
+
+- (NSString *)branchKey
+{
+    return self[RNBranchConfigBranchKeyOption];
 }
 
 - (NSString *)liveKey

--- a/ios/RNBranchConfig.m
+++ b/ios/RNBranchConfig.m
@@ -15,6 +15,7 @@ NSString * _Nonnull const RNBranchConfigLiveKeyOption = @"liveKey";
 NSString * _Nonnull const RNBranchConfigTestKeyOption = @"testKey";
 NSString * _Nonnull const RNBranchConfigUseTestInstanceOption = @"useTestInstance";
 NSString * _Nonnull const RNBranchConfigDelayInitToCheckForSearchAdsOption = @"delayInitToCheckForSearchAds";
+NSString * _Nonnull const RNBranchConfigAppleSearchAdsDebugModeOption = @"appleSearchAdsDebugMode";
 
 @interface RNBranchConfig()
 @property (nonatomic) NSDictionary *configuration;
@@ -119,6 +120,12 @@ NSString * _Nonnull const RNBranchConfigDelayInitToCheckForSearchAdsOption = @"d
 - (BOOL)delayInitToCheckForSearchAds
 {
     NSNumber *number = self[RNBranchConfigDelayInitToCheckForSearchAdsOption];
+    return number.boolValue;
+}
+
+- (BOOL)appleSearchAdsDebugMode
+{
+    NSNumber *number = self[RNBranchConfigAppleSearchAdsDebugModeOption];
     return number.boolValue;
 }
 

--- a/ios/RNBranchConfig.m
+++ b/ios/RNBranchConfig.m
@@ -25,12 +25,14 @@ NSString * _Nonnull const RNBranchConfigUseTestInstanceOption = @"useTestInstanc
 
 + (RNBranchConfig * _Nonnull)instance
 {
-    static RNBranchConfig *_instance;
-    static dispatch_once_t once = 0;
-    dispatch_once(&once, ^{
-        _instance = [[RNBranchConfig alloc] init];
-    });
-    return _instance;
+    @synchronized(self) {
+        static RNBranchConfig *_instance;
+        static dispatch_once_t once = 0;
+        dispatch_once(&once, ^{
+            _instance = [[RNBranchConfig alloc] init];
+        });
+        return _instance;
+    }
 }
 
 - (instancetype)init

--- a/scripts/addBranchConfig.js
+++ b/scripts/addBranchConfig.js
@@ -1,12 +1,16 @@
 var androidUtil = require('./androidUtil')
 var fs = require('fs')
+var log = require('npmlog')
 var iosUtil = require('./iosUtil')
+
+log.heading = 'react-native-branch'
 
 // TODO: Should it be possible to use just branch.debug.json w/o branch.json?
 // This seems like an unlikely configuration. Maybe the check should just be
 // for branch.json, or if just branch.debug.json exists, a warning should be
 // generated.
 if (!fs.existsSync('./branch.json') && !fs.existsSync('./branch.debug.json')) {
+  log.info('branch.json not found. See https://rnbranch.app.link/branch-json for more information.')
   return
 }
 

--- a/scripts/addBranchConfig.js
+++ b/scripts/addBranchConfig.js
@@ -1,6 +1,7 @@
 const androidUtil = require('./androidUtil')
 const fs = require('fs')
 const log = require('npmlog')
+const path = require('path')
 const iosUtil = require('./iosUtil')
 
 log.heading = 'react-native-branch'
@@ -9,7 +10,7 @@ log.heading = 'react-native-branch'
 // This seems like an unlikely configuration. Maybe the check should just be
 // for branch.json, or if just branch.debug.json exists, a warning should be
 // generated.
-if (!fs.existsSync('./branch.json') && !fs.existsSync('./branch.debug.json')) {
+if (!fs.existsSync(path.join('.', 'branch.json')) && !fs.existsSync(path.join('.', 'branch.debug.json'))) {
   log.info('branch.json not found. See https://rnbranch.app.link/branch-json for more information.')
   return
 }

--- a/scripts/addBranchConfig.js
+++ b/scripts/addBranchConfig.js
@@ -1,7 +1,7 @@
-var androidUtil = require('./androidUtil')
-var fs = require('fs')
-var log = require('npmlog')
-var iosUtil = require('./iosUtil')
+const androidUtil = require('./androidUtil')
+const fs = require('fs')
+const log = require('npmlog')
+const iosUtil = require('./iosUtil')
 
 log.heading = 'react-native-branch'
 

--- a/scripts/androidUtil.js
+++ b/scripts/androidUtil.js
@@ -1,18 +1,21 @@
 const fs = require('fs')
 const log = require('npmlog')
+const path = require('path')
 
 log.heading = 'react-native-branch'
 
 function addBranchConfigToAndroidAssetsFolder() {
   if (fs.existsSync('./branch.json')) {
     ensureAndroidAssetsFolder('main')
-    addSymbolicLink('../../../../../branch.json', './android/app/src/main/assets/branch.json')
+    addSymbolicLink(path.join('..', '..', '..', '..', '..', 'branch.json'),
+      path.join('.', 'android', 'app', 'src', 'main', 'assets', 'branch.json'))
   }
 
   // branch.debug.json will be available as branch.json in debug builds
   if (fs.existsSync('./branch.debug.json')) {
     ensureAndroidAssetsFolder('debug')
-    addSymbolicLink('../../../../../branch.debug.json', './android/app/src/debug/assets/branch.json')
+    addSymbolicLink(path.join('..', '..', '..', '..', '..', 'branch.debug.json'),
+      path.join('.', 'android', 'app', 'src', 'debug', 'assets', 'branch.json'))
   }
 
   log.info('Added Branch configuration to android project')
@@ -65,7 +68,7 @@ function removeSymbolicLink(path) {
 }
 
 function ensureAndroidAssetsFolder(buildType) {
-  ensureDirectory('./android/app/src/' + buildType + '/assets')
+  ensureDirectory(path.join('.', 'android', 'app', 'src', buildType, 'assets'))
 }
 
 function ensureDirectory(path) {
@@ -87,15 +90,34 @@ function ensureDirectory(path) {
 }
 
 function dirname(path) {
-  if (!path.match(/\//)) return path
+  if (!path.search(path.sep)) return path
 
-  return /^(.*)\/[^/]+$/.exec(path)[1]
+  const components = path.split(path.sep)
+  components.splice(components.count - 1, 1)
+  return components.join(path.sep)
 }
 
 function removeBranchConfigFromAndroidAssetsFolder() {
-  removeSymbolicLink('./android/app/src/main/assets/branch.json')
-  removeSymbolicLink('./android/app/src/debug/assets/branch.json')
+  removeSymbolicLink(path.join('.', 'android', 'app', 'src', 'main', 'assets', 'branch.json'))
+  removeSymbolicLink(path.join('.', 'android', 'app', 'src', 'debug', 'assets', 'branch.json'))
   log.info('Removed Branch configuration from Android project')
+}
+
+function androidPackageName() {
+  const path = path.join('.', 'android', 'app', 'src', 'main', 'AndroidManifest.xml')
+  manifest = fs.readFileSync(path)
+  const regex = /package=["']([A-Za-z\.0-9])["']/
+  if (!manifest.match(regex)) throw 'package name not found in ' + path
+  return regex.exec(manifest)[1]
+}
+
+function androidPackageDir() {
+  return path.join('.', 'android', 'app', 'src', 'main', 'java', androidPackageName().replace(/\./, path.sep))
+}
+
+function replaceBranchGetAutoinstnace() {
+  const packageDir = androidPackageDir()
+  source = fs.readFileSync(path.join())
 }
 
 module.exports = {

--- a/scripts/androidUtil.js
+++ b/scripts/androidUtil.js
@@ -1,5 +1,5 @@
-var fs = require('fs')
-var log = require('npmlog')
+const fs = require('fs')
+const log = require('npmlog')
 
 log.heading = 'react-native-branch'
 
@@ -20,9 +20,9 @@ function addBranchConfigToAndroidAssetsFolder() {
 
 function addSymbolicLink(linkPath, path) {
   try {
-    var stats = fs.lstatSync(path)
+    const stats = fs.lstatSync(path)
     if (stats && stats.isSymbolicLink()) {
-      var dest = fs.readlinkSync(path)
+      const dest = fs.readlinkSync(path)
       if (dest == linkPath) {
         log.warn(path + ' already present in Android app')
         return
@@ -48,16 +48,16 @@ function addSymbolicLink(linkPath, path) {
 
 function removeSymbolicLink(path) {
   try {
-    var stats = fs.lstatSync(path)
+    const stats = fs.lstatSync(path)
+
+    if (!stats.isSymbolicLink()) {
+      log.warn(path + ' is not a symbolic link. Not removing.')
+      return
+    }
   }
   catch (error) {
     if (error.code != 'ENOENT') throw error
     // Not present. Quietly do nothing.
-    return
-  }
-
-  if (!stats.isSymbolicLink()) {
-    log.warn(path + ' is not a symbolic link. Not removing.')
     return
   }
 
@@ -70,7 +70,7 @@ function ensureAndroidAssetsFolder(buildType) {
 
 function ensureDirectory(path) {
   try {
-    var stats = fs.statSync(path)
+    const stats = fs.statSync(path)
 
     if (!stats.isDirectory()) {
       throw(srcDir + ' exists and is not a directory.')
@@ -79,7 +79,7 @@ function ensureDirectory(path) {
   catch (error) {
     if (error.code != 'ENOENT') throw error
 
-    var parent = dirname(path)
+    const parent = dirname(path)
     if (parent !== path) ensureDirectory(parent)
 
     fs.mkdirSync(path, 0o777)

--- a/scripts/androidUtil.js
+++ b/scripts/androidUtil.js
@@ -95,7 +95,7 @@ function dirname(path) {
 function removeBranchConfigFromAndroidAssetsFolder() {
   removeSymbolicLink('./android/app/src/main/assets/branch.json')
   removeSymbolicLink('./android/app/src/debug/assets/branch.json')
-  log.info('Removed Branch configuration from Android project.')
+  log.info('Removed Branch configuration from Android project')
 }
 
 module.exports = {

--- a/scripts/androidUtil.js
+++ b/scripts/androidUtil.js
@@ -1,6 +1,8 @@
 var fs = require('fs')
 var log = require('npmlog')
 
+log.heading = 'react-native-branch'
+
 function addBranchConfigToAndroidAssetsFolder() {
   if (fs.existsSync('./branch.json')) {
     ensureAndroidAssetsFolder('main')
@@ -93,7 +95,7 @@ function dirname(path) {
 function removeBranchConfigFromAndroidAssetsFolder() {
   removeSymbolicLink('./android/app/src/main/assets/branch.json')
   removeSymbolicLink('./android/app/src/debug/assets/branch.json')
-  log.info('removed Branch configuration from Android project.')
+  log.info('Removed Branch configuration from Android project.')
 }
 
 module.exports = {

--- a/scripts/iosUtil.js
+++ b/scripts/iosUtil.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const log = require('npmlog')
+const path = require('path')
 const xcode = require('xcode')
 
 log.heading = 'react-native-branch'
@@ -11,32 +12,32 @@ function addBranchConfigToXcodeProject() {
     return
   }
 
-  const xcodeprojName = './ios/' + projectName + '.xcodeproj'
-  const projectPbxprojName = xcodeprojName + '/project.pbxproj'
+  const xcodeprojPath = path.join('.', 'ios', projectName + '.xcodeproj')
+  const projectPbxprojPath = path.join(xcodeprojPath, 'project.pbxproj')
 
-  const project = xcode.project(projectPbxprojName)
+  const project = xcode.project(projectPbxprojPath)
   project.parse(function(error) {
     if (error) {
-      log.error('Error loading ' + xcodeprojName)
+      log.error('Error loading ' + xcodeprojPath)
       return
     }
 
-    if (fs.existsSync('./branch.json')) {
+    if (fs.existsSync(path.join('.', 'branch.json'))) {
       // path relative to group
-      includePathInProject(project, projectName, '../branch.json')
+      includePathInProject(project, projectName, path.join('..', 'branch.json'))
     }
 
-    if (fs.existsSync('./branch.debug.json')) {
+    if (fs.existsSync(path.join('.', 'branch.debug.json'))) {
       // path relative to group
-      includePathInProject(project, projectName, '../branch.debug.json')
+      includePathInProject(project, projectName, path.join('..', 'branch.debug.json'))
     }
 
-    if (fs.writeFileSync(projectPbxprojName, project.writeSync()) <= 0) {
+    if (fs.writeFileSync(projectPbxprojPath, project.writeSync()) <= 0) {
       log.error('error writing updated project')
       return
     }
 
-    log.info('Added Branch configuration to project ' + xcodeprojName)
+    log.info('Added Branch configuration to project ' + xcodeprojPath)
   })
 }
 
@@ -47,26 +48,26 @@ function removeBranchConfigFromXcodeProject() {
     return
   }
 
-  const xcodeprojName = './ios/' + projectName + '.xcodeproj'
-  const projectPbxprojName = xcodeprojName + '/project.pbxproj'
+  const xcodeprojPath = path.join('.', 'ios', projectName + '.xcodeproj')
+  const projectPbxprojPath = path.join(xcodeprojPath, 'project.pbxproj')
 
-  const project = xcode.project(projectPbxprojName)
+  const project = xcode.project(projectPbxprojPath)
   project.parse(function(error) {
     if (error) {
-      log.error('Error loading ' + xcodeprojName)
+      log.error('Error loading ' + xcodeprojPath)
       return
     }
 
     // paths relative to group
-    removePathFromProject(project, projectName, '../branch.json')
-    removePathFromProject(project, projectName, '../branch.debug.json')
+    removePathFromProject(project, projectName, path.join('..', 'branch.json'))
+    removePathFromProject(project, projectName, path.join('..', 'branch.debug.json'))
 
-    if (fs.writeFileSync(projectPbxprojName, project.writeSync()) <= 0) {
+    if (fs.writeFileSync(projectPbxprojPath, project.writeSync()) <= 0) {
       log.error('error writing updated project')
       return
     }
 
-    log.info('Removed Branch configuration from project ' + xcodeprojName)
+    log.info('Removed Branch configuration from project ' + xcodeprojPath)
   })
 }
 
@@ -143,7 +144,7 @@ function correctForPath(file, project, group) {
 
 function findXcodeProjectName() {
   // look for a .xcodeproj directory under ios
-  files = fs.readdirSync('./ios')
+  files = fs.readdirSync(path.join('.', 'ios'))
 
   const regex = /^([^/]+)\.xcodeproj$/
 
@@ -152,7 +153,7 @@ function findXcodeProjectName() {
       return false
     }
 
-    stats = fs.statSync('./ios/' + filename)
+    stats = fs.statSync(path.join('.', 'ios', filename))
 
     return stats.isDirectory()
   })

--- a/scripts/iosUtil.js
+++ b/scripts/iosUtil.js
@@ -2,6 +2,8 @@ var fs = require('fs')
 var log = require('npmlog')
 var xcode = require('xcode')
 
+log.heading = 'react-native-branch'
+
 function addBranchConfigToXcodeProject() {
   var projectName = findXcodeProjectName()
   if (!projectName) {

--- a/scripts/iosUtil.js
+++ b/scripts/iosUtil.js
@@ -1,20 +1,20 @@
-var fs = require('fs')
-var log = require('npmlog')
-var xcode = require('xcode')
+const fs = require('fs')
+const log = require('npmlog')
+const xcode = require('xcode')
 
 log.heading = 'react-native-branch'
 
 function addBranchConfigToXcodeProject() {
-  var projectName = findXcodeProjectName()
+  const projectName = findXcodeProjectName()
   if (!projectName) {
     log.error('could not find an Xcode project')
     return
   }
 
-  var xcodeprojName = './ios/' + projectName + '.xcodeproj'
-  var projectPbxprojName = xcodeprojName + '/project.pbxproj'
+  const xcodeprojName = './ios/' + projectName + '.xcodeproj'
+  const projectPbxprojName = xcodeprojName + '/project.pbxproj'
 
-  var project = xcode.project(projectPbxprojName)
+  const project = xcode.project(projectPbxprojName)
   project.parse(function(error) {
     if (error) {
       log.error('Error loading ' + xcodeprojName)
@@ -41,16 +41,16 @@ function addBranchConfigToXcodeProject() {
 }
 
 function removeBranchConfigFromXcodeProject() {
-  var projectName = findXcodeProjectName()
+  const projectName = findXcodeProjectName()
   if (!projectName) {
     log.error('could not find an Xcode project')
     return
   }
 
-  var xcodeprojName = './ios/' + projectName + '.xcodeproj'
-  var projectPbxprojName = xcodeprojName + '/project.pbxproj'
+  const xcodeprojName = './ios/' + projectName + '.xcodeproj'
+  const projectPbxprojName = xcodeprojName + '/project.pbxproj'
 
-  var project = xcode.project(projectPbxprojName)
+  const project = xcode.project(projectPbxprojName)
   project.parse(function(error) {
     if (error) {
       log.error('Error loading ' + xcodeprojName)
@@ -71,14 +71,14 @@ function removeBranchConfigFromXcodeProject() {
 }
 
 function includePathInProject(project, groupName, path) {
-  var groupKey = getGroupKeyByName(project, groupName)
+  const groupKey = getGroupKeyByName(project, groupName)
   if (!groupKey) {
       log.error('Could not find key for group ' + groupName)
       return
   }
 
   // path relative to group
-  var file = project.addFile(path, groupKey)
+  const file = project.addFile(path, groupKey)
   if (!file) {
     // TODO: Can get here if the file is already in the project
     log.error('Failed to add file to project')
@@ -94,7 +94,7 @@ function includePathInProject(project, groupName, path) {
 }
 
 function removePathFromProject(project, groupName, path) {
-  var file = project.removeFile(path, {})
+  const file = project.removeFile(path, {})
   if (!file) {
     log.warn('Did not find ' + path + ' in project')
     return
@@ -103,7 +103,7 @@ function removePathFromProject(project, groupName, path) {
   file.target = getTargetKeyByName(project, groupName)
   correctForPath(file, project, groupName)
 
-  var groupKey = getGroupKeyByName(project, groupName)
+  const groupKey = getGroupKeyByName(project, groupName)
   if (!groupKey) {
     log.error('Could not find key for group ' + groupName)
     return
@@ -115,25 +115,25 @@ function removePathFromProject(project, groupName, path) {
 }
 
 function getGroupKeyByName(project, groupName) {
-  var objects = project.hash.project.objects['PBXGroup']
-  for (var key in objects) {
-    var name = objects[key].name
+  const objects = project.hash.project.objects['PBXGroup']
+  for (const key in objects) {
+    const name = objects[key].name
     if (name == groupName) return key
   }
   return null
 }
 
 function getTargetKeyByName(project, targetName) {
-  var targets = project.pbxNativeTargetSection()
-  for (var key in targets) {
-    var name = targets[key].name
+  const targets = project.pbxNativeTargetSection()
+  for (const key in targets) {
+    const name = targets[key].name
     if (name == targetName) return key
   }
   return null
 }
 
 function correctForPath(file, project, group) {
-    var r_group_dir = new RegExp('^' + group + '[\\\\/]');
+    const r_group_dir = new RegExp('^' + group + '[\\\\/]');
 
     if (project.pbxGroupByName(group).path)
         file.path = file.path.replace(r_group_dir, '');
@@ -145,7 +145,7 @@ function findXcodeProjectName() {
   // look for a .xcodeproj directory under ios
   files = fs.readdirSync('./ios')
 
-  var regex = /^([^/]+)\.xcodeproj$/
+  const regex = /^([^/]+)\.xcodeproj$/
 
   projectDir = files.find(function(filename) {
     if (!filename.match(regex)) {
@@ -159,7 +159,7 @@ function findXcodeProjectName() {
 
   if (!projectDir) return null
 
-  var result = regex.exec(projectDir)
+  const result = regex.exec(projectDir)
   return result[1]
 }
 

--- a/scripts/removeBranchConfig.js
+++ b/scripts/removeBranchConfig.js
@@ -1,5 +1,5 @@
-var androidUtil = require('./androidUtil')
-var iosUtil = require('./iosUtil')
+const androidUtil = require('./androidUtil')
+const iosUtil = require('./iosUtil')
 
 androidUtil.removeBranchConfigFromAndroidAssetsFolder()
 iosUtil.removeBranchConfigFromXcodeProject()

--- a/test/helpers/RNBranch.mock.js
+++ b/test/helpers/RNBranch.mock.js
@@ -60,8 +60,6 @@ export function mock(object: Object, methodName: String, mockMethod: Function) {
 }
 
 export function unmock() {
-  mockedMethods.forEach((m) => {
-    m.object[m.method] = m.original
-  })
+  mockedMethods.forEach(({object, method, original}) => object[method] = original)
   mockedMethods = []
 }


### PR DESCRIPTION
The `branch.json` file can now be used to control key selection using several new parameters. Support was also added for Apple Search Ads on iOS.

New parameters:

|key|description|type|
|---|---|---|
|branchKey|If set, the specified key overrides all other settings, including the Info.plist, AndroidManifest.xml and the liveKey and testKey settings here.|String|
|liveKey|If branchKey is not set and useTestInstance is false or absent, this key will be used to override the keys from the Info.plist and AndroidManifest.xml|String|
|testKey|If branchKey is not set and useTestInstance is true, this key will be used to override the keys from the Info.plist and AndroidManifest.xml|String|
|useTestInstance|If branchKey is not set and useTestInstance is true, the testKey from branch.json will be used if present. If branchKey and testKey are not set: On iOS, the test key from the Info.plist will be used, if present. On Android, the io.branch.sdk.TestMode metadata key will determine which instance is used.|Boolean|
|appleSearchAdsDebugMode|If true, `setAppleSearchAdsDebugMode` will be called on the iOS Branch instance. Ignored on Android.|Boolean|
|delayInitToCheckForSearchAds|If true, `delayInitToCheckForSearchAds` will be called on the iOS Branch instance. Ignored on Android.|Boolean|
