### PR TITLE
Breaking Change - Remove overridden createJSModules

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchPackage.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchPackage.java
@@ -21,11 +21,6 @@ public class RNBranchPackage implements ReactPackage {
   }
 
   @Override
-  public List<Class<? extends JavaScriptModule>> createJSModules() {
-  	return Collections.emptyList();
-  }
-
-  @Override
   public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
   	return Collections.emptyList();
   }


### PR DESCRIPTION
Required for React Native 0.47+

Reference commit: facebook/react-native@ce6fb33