### PR TITLE
Automation updates

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     escape (0.0.4)
     ethon (0.10.1)
       ffi (>= 1.3.0)
-    excon (0.58.0)
+    excon (0.59.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     faraday-cookie_jar (0.0.6)
@@ -101,7 +101,8 @@ GEM
       xcodeproj (>= 1.5.0, < 2.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-branch (0.3.0)
+    fastlane-plugin-branch (0.4.1)
+      fastlane-plugin-patch
       plist
       xcodeproj
     fastlane-plugin-patch (0.3.0)
@@ -116,7 +117,7 @@ GEM
       net-http-persistent (>= 2.7)
       net-http-pipeline
     gh_inspector (1.0.3)
-    google-api-client (0.13.4)
+    google-api-client (0.13.5)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (~> 0.5)
       httpclient (>= 2.8.1, < 3.0)
@@ -151,7 +152,7 @@ GEM
     mini_magick (4.5.1)
     minitest (5.10.3)
     molinillo (0.5.7)
-    multi_json (1.12.1)
+    multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nanaimo (0.2.3)

--- a/fastlane/lib/update_native_sdks.rb
+++ b/fastlane/lib/update_native_sdks.rb
@@ -32,7 +32,7 @@ module Fastlane
             native-tests/ios
           }.each { |f| pod_install f }
 
-          commit
+          commit if params[:commit]
         end
 
         def available_options

--- a/fastlane/lib/update_native_sdks.rb
+++ b/fastlane/lib/update_native_sdks.rb
@@ -7,7 +7,7 @@ module Fastlane
         UI = FastlaneCore::UI
 
         def run(params)
-          update_submodules
+          update_submodules params
 
           @android_subdir = File.expand_path 'android', '.'
           @ios_subdir = File.expand_path 'ios', '.'
@@ -36,20 +36,41 @@ module Fastlane
         end
 
         def available_options
-          []
+          [
+            FastlaneCore::ConfigItem.new(key: :android_checkout,
+                                 description: "A commit, tag or branch to check out in the Android SDK instead of the latest tag",
+                                     optional: true,
+                                         type: String),
+            FastlaneCore::ConfigItem.new(key: :ios_checkout,
+                                 description: "A commit, tag or branch to checkout out in the iOS SDK instead of the latest tag",
+                                     optional: true,
+                                         type: String),
+            FastlaneCore::ConfigItem.new(key: :commit,
+                                 description: "Determines whether to commit the result to SCM",
+                                    optional: true,
+                               default_value: true,
+                                   is_string: false)
+          ]
         end
 
         def commit
           `git commit -a -m'[Fastlane] Branch native SDK update'`
         end
 
-        def update_submodules
+        def update_submodules(params)
           UI.message "Updating native SDK submodules..."
-          %w{native-sdks/android native-sdks/ios}.each do |folder|
+          ['android', 'ios'].each do |platform|
+            folder = "native-sdks/#{platform}"
             Dir.chdir(folder) do
               `git checkout -q master`
               `git pull --tags -q origin master`
-              checkout_last_git_tag
+              key = "#{platform}_checkout".to_sym
+              commit = params[key]
+              if commit
+                `git checkout -q #{commit}`
+              else
+                checkout_last_git_tag
+              end
               UI.message "Updated submodule in #{folder}"
             end
           end


### PR DESCRIPTION
Added some options to the `update_native_sdks` action to make it easier to work with tags and branches in the native repos: `:android_checkout`, `:ios_checkout` and `:commit`. For example, to work with the framework-improvements branch in the iOS repo without committing:

```Ruby
update_native_sdks ios_checkout: "framework-improvements", commit: false
```

The `:android_checkout` and `:ios_checkout` keys can take as arguments branches, tags or commits (SHA). The string is just passed to `git checkout`.