### PR TITLE
Update examples

### DIFF
--- a/examples/testbed_simple/.babelrc
+++ b/examples/testbed_simple/.babelrc
@@ -1,3 +1,3 @@
 {
-"presets": ["react-native"]
+  "presets": ["react-native"]
 }

--- a/examples/testbed_simple/.flowconfig
+++ b/examples/testbed_simple/.flowconfig
@@ -26,8 +26,6 @@ emoji=true
 
 module.system=haste
 
-experimental.strict_type_args=true
-
 munge_underscores=true
 
 module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
@@ -36,11 +34,12 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(3[0-8]\\|[1-2][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(3[0-8]\\|1[0-9]\\|[1-2][0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(4[0-9]\\|[1-3][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(4[0-9]\\|[1-3][0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
+suppress_comment=\\(.\\|\n\\)*\\$FlowExpectedError
 
 unsafe.enable_getters_and_setters=true
 
 [version]
-^0.38.0
+^0.49.1

--- a/examples/testbed_simple/android/app/BUCK
+++ b/examples/testbed_simple/android/app/BUCK
@@ -1,5 +1,3 @@
-import re
-
 # To learn about Buck see [Docs](https://buckbuild.com/).
 # To run your application with Buck:
 # - install Buck
@@ -11,8 +9,9 @@ import re
 #
 
 lib_deps = []
+
 for jarfile in glob(['libs/*.jar']):
-  name = 'jars__' + re.sub(r'^.*/([^/]+)\.jar$', r'\1', jarfile)
+  name = 'jars__' + jarfile[jarfile.rindex('/') + 1: jarfile.rindex('.jar')]
   lib_deps.append(':' + name)
   prebuilt_jar(
     name = name,
@@ -20,7 +19,7 @@ for jarfile in glob(['libs/*.jar']):
   )
 
 for aarfile in glob(['libs/*.aar']):
-  name = 'aars__' + re.sub(r'^.*/([^/]+)\.aar$', r'\1', aarfile)
+  name = 'aars__' + aarfile[aarfile.rindex('/') + 1: aarfile.rindex('.aar')]
   lib_deps.append(':' + name)
   android_prebuilt_aar(
     name = name,
@@ -28,39 +27,39 @@ for aarfile in glob(['libs/*.aar']):
   )
 
 android_library(
-  name = 'all-libs',
-  exported_deps = lib_deps
+    name = "all-libs",
+    exported_deps = lib_deps,
 )
 
 android_library(
-  name = 'app-code',
-  srcs = glob([
-    'src/main/java/**/*.java',
-  ]),
-  deps = [
-    ':all-libs',
-    ':build_config',
-    ':res',
-  ],
+    name = "app-code",
+    srcs = glob([
+        "src/main/java/**/*.java",
+    ]),
+    deps = [
+        ":all-libs",
+        ":build_config",
+        ":res",
+    ],
 )
 
 android_build_config(
-  name = 'build_config',
-  package = 'com.testbed_simple',
+    name = "build_config",
+    package = "com.testbed_simple",
 )
 
 android_resource(
-  name = 'res',
-  res = 'src/main/res',
-  package = 'com.testbed_simple',
+    name = "res",
+    package = "com.testbed_simple",
+    res = "src/main/res",
 )
 
 android_binary(
-  name = 'app',
-  package_type = 'debug',
-  manifest = 'src/main/AndroidManifest.xml',
-  keystore = '//android/keystores:debug',
-  deps = [
-    ':app-code',
-  ],
+    name = "app",
+    keystore = "//android/keystores:debug",
+    manifest = "src/main/AndroidManifest.xml",
+    package_type = "debug",
+    deps = [
+        ":app-code",
+    ],
 )

--- a/examples/testbed_simple/android/app/build.gradle
+++ b/examples/testbed_simple/android/app/build.gradle
@@ -33,6 +33,13 @@ import com.android.build.OutputFile
  *   // bundleInPaidRelease: true,
  *   // bundleInBeta: true,
  *
+ *   // whether to disable dev mode in custom build variants (by default only disabled in release)
+ *   // for example: to disable dev mode in the staging build type (if configured)
+ *   devDisabledInStaging: true,
+ *   // The configuration property can be in the following formats
+ *   //         'devDisabledIn${productFlavor}${buildType}'
+ *   //         'devDisabledIn${buildType}'
+ *
  *   // the root of your project, i.e. where "package.json" lives
  *   root: "../../",
  *
@@ -58,7 +65,7 @@ import com.android.build.OutputFile
  *   inputExcludes: ["android/**", "ios/**"],
  *
  *   // override which node gets called and with what additional arguments
- *   nodeExecutableAndArgs: ["node"]
+ *   nodeExecutableAndArgs: ["node"],
  *
  *   // supply additional arguments to the packager
  *   extraPackagerArgs: []

--- a/examples/testbed_simple/android/app/proguard-rules.pro
+++ b/examples/testbed_simple/android/app/proguard-rules.pro
@@ -50,6 +50,10 @@
 
 -dontwarn com.facebook.react.**
 
+# TextLayoutBuilder uses a non-public Android constructor within StaticLayout.
+# See libs/proxy/src/main/java/com/facebook/fbui/textlayoutbuilder/proxy for details.
+-dontwarn android.text.StaticLayout
+
 # okhttp
 
 -keepattributes Signature

--- a/examples/testbed_simple/android/keystores/BUCK
+++ b/examples/testbed_simple/android/keystores/BUCK
@@ -1,8 +1,8 @@
 keystore(
-  name = 'debug',
-  store = 'debug.keystore',
-  properties = 'debug.keystore.properties',
-  visibility = [
-    'PUBLIC',
-  ],
+    name = "debug",
+    properties = "debug.keystore.properties",
+    store = "debug.keystore",
+    visibility = [
+        "PUBLIC",
+    ],
 )

--- a/examples/testbed_simple/app.json
+++ b/examples/testbed_simple/app.json
@@ -1,0 +1,4 @@
+{
+  "name": "testbed_simple",
+  "displayName": "testbed_simple"
+}

--- a/examples/testbed_simple/ios/testbed_simple.xcodeproj/project.pbxproj
+++ b/examples/testbed_simple/ios/testbed_simple.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		7BAA95291F57639400C57B54 /* CoreSpotlight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BAA95281F57639400C57B54 /* CoreSpotlight.framework */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		D9ED2727DA264331959EEF70 /* libreact-native-branch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BB4222F61210465898829C17 /* libreact-native-branch.a */; };
+		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -240,6 +241,13 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		ADBDB9261DFEBF0700ED6528 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 358F4ED71D1E81A9004DF814;
+			remoteInfo = RCTBlob;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -274,6 +282,7 @@
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		833C26E28CFB41BB8628EAD0 /* RNBranch.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNBranch.xcodeproj; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; };
 		BB4222F61210465898829C17 /* libreact-native-branch.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libreact-native-branch.a"; sourceTree = "<group>"; };
+		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -292,6 +301,8 @@
 				7BAA95291F57639400C57B54 /* CoreSpotlight.framework in Frameworks */,
 				7BAA95151F57634800C57B54 /* SafariServices.framework in Frameworks */,
 				7BAA95131F57634200C57B54 /* AdSupport.framework in Frameworks */,
+				ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */,
+				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
@@ -436,6 +447,7 @@
 				3DAD3EAB1DF850E9000B6D8A /* libcxxreact.a */,
 				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
 				3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */,
+				3DAD3EA31DF850E9000B6D8A /* libReact-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -482,6 +494,7 @@
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
+				ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
 				00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */,
 				78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */,
@@ -516,6 +529,7 @@
 			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
+			usesTabs = 0;
 		};
 		83CBBA001A601CBA00E9B192 /* Products */ = {
 			isa = PBXGroup;
@@ -524,6 +538,14 @@
 				00E356EE1AD99517003FC87E /* testbed_simpleTests.xctest */,
 				2D02E47B1E0B4A5D006451C7 /* testbed_simple-tvOS.app */,
 				2D02E4901E0B4A5D006451C7 /* testbed_simple-tvOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ADBDB9201DFEBF0600ED6528 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -655,6 +677,10 @@
 				{
 					ProductGroup = 5E91572E1DD0AC6500FF2AA8 /* Products */;
 					ProjectRef = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
+				},
+				{
+					ProductGroup = ADBDB9201DFEBF0600ED6528 /* Products */;
+					ProjectRef = ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */;
 				},
 				{
 					ProductGroup = 00C302B61ABCB90400DB3ED1 /* Products */;
@@ -806,10 +832,10 @@
 			remoteRef = 3DAD3E981DF850E9000B6D8A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		3DAD3EA31DF850E9000B6D8A /* libReact.a */ = {
+		3DAD3EA31DF850E9000B6D8A /* libReact-tvOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libReact.a;
+			path = "libReact-tvOS.a";
 			remoteRef = 3DAD3EA21DF850E9000B6D8A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -890,6 +916,13 @@
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTBlob.a;
+			remoteRef = ADBDB9261DFEBF0700ED6528 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -940,7 +973,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -954,7 +987,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/examples/testbed_simple/ios/testbed_simple/Info.plist
+++ b/examples/testbed_simple/ios/testbed_simple/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>testbed_simple</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/examples/testbed_simple/ios/testbed_simpleTests/testbed_simpleTests.m
+++ b/examples/testbed_simple/ios/testbed_simpleTests/testbed_simpleTests.m
@@ -37,7 +37,7 @@
 
 - (void)testRendersWelcomeScreen
 {
-  UIViewController *vc = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+  UIViewController *vc = [[[RCTSharedApplication() delegate] window] rootViewController];
   NSDate *date = [NSDate dateWithTimeIntervalSinceNow:TIMEOUT_SECONDS];
   BOOL foundElement = NO;
 

--- a/examples/testbed_simple/package-lock.json
+++ b/examples/testbed_simple/package-lock.json
@@ -70,9 +70,9 @@
 			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
 		},
 		"ansi-escapes": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
-			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
+			"integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs="
 		},
 		"ansi-regex": {
 			"version": "2.1.1",
@@ -88,7 +88,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
 			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-			"dev": true,
 			"requires": {
 				"micromatch": "2.3.11",
 				"normalize-path": "2.1.1"
@@ -110,35 +109,6 @@
 			"requires": {
 				"delegates": "1.0.0",
 				"readable-stream": "2.3.3"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"readable-stream": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
-				}
 			}
 		},
 		"argparse": {
@@ -154,7 +124,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true,
 			"requires": {
 				"arr-flatten": "1.1.0"
 			}
@@ -162,8 +131,7 @@
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"dev": true
+			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
 		},
 		"array-differ": {
 			"version": "1.0.0",
@@ -191,14 +159,6 @@
 			"resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
 			"integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
 		},
-		"array-union": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"requires": {
-				"array-uniq": "1.0.3"
-			}
-		},
 		"array-uniq": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -207,13 +167,13 @@
 		"array-unique": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
-			"dev": true
+			"integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
 		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+			"integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+			"dev": true
 		},
 		"art": {
 			"version": "0.10.1",
@@ -259,9 +219,9 @@
 			"integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
 		},
 		"babel-code-frame": {
-			"version": "6.22.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
 				"chalk": "1.1.3",
 				"esutils": "2.0.2",
@@ -269,20 +229,20 @@
 			}
 		},
 		"babel-core": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
+			"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 			"requires": {
-				"babel-code-frame": "6.22.0",
-				"babel-generator": "6.25.0",
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.0",
 				"babel-helpers": "6.24.1",
 				"babel-messages": "6.23.0",
-				"babel-register": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
 				"convert-source-map": "1.5.0",
 				"debug": "2.6.8",
 				"json5": "0.5.1",
@@ -291,7 +251,7 @@
 				"path-is-absolute": "1.0.1",
 				"private": "0.1.7",
 				"slash": "1.0.0",
-				"source-map": "0.5.6"
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"json5": {
@@ -302,27 +262,27 @@
 			}
 		},
 		"babel-generator": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-			"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
 			"requires": {
 				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
 				"detect-indent": "4.0.0",
 				"jsesc": "1.3.0",
 				"lodash": "4.17.4",
-				"source-map": "0.5.6",
+				"source-map": "0.5.7",
 				"trim-right": "1.0.1"
 			}
 		},
 		"babel-helper-builder-react-jsx": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-			"integrity": "sha1-CteRfjPI11HmRtrKTnfMGTd9LLw=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+			"integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
 				"esutils": "2.0.2"
 			}
 		},
@@ -332,19 +292,19 @@
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
 				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-define-map": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz",
-			"integrity": "sha1-epdH8ljYlH0y1RX2qhx70CIEoIA=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
+			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
 				"lodash": "4.17.4"
 			}
 		},
@@ -354,10 +314,10 @@
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
 				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -365,8 +325,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -374,8 +334,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -383,18 +343,30 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-regex": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-			"integrity": "sha1-024i+rEAjXnYhkjjIRaGgShFbOg=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
+			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
 				"lodash": "4.17.4"
+			}
+		},
+		"babel-helper-remap-async-to-generator": {
+			"version": "6.24.1",
+			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+			"requires": {
+				"babel-helper-function-name": "6.24.1",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -404,10 +376,10 @@
 			"requires": {
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-helpers": {
@@ -415,8 +387,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-jest": {
@@ -425,7 +397,7 @@
 			"integrity": "sha1-WTI87ZmjqE01naIZyogQdP/Gzj8=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
+				"babel-core": "6.26.0",
 				"babel-plugin-istanbul": "4.1.4",
 				"babel-preset-jest": "19.0.0"
 			}
@@ -435,7 +407,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -443,7 +415,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-external-helpers": {
@@ -451,7 +423,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-external-helpers/-/babel-plugin-external-helpers-6.22.0.tgz",
 			"integrity": "sha1-IoX0iwK9Xe3oUXXK+MYuhq3M76E=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -461,7 +433,7 @@
 			"dev": true,
 			"requires": {
 				"find-up": "2.1.0",
-				"istanbul-lib-instrument": "1.7.4",
+				"istanbul-lib-instrument": "1.8.0",
 				"test-exclude": "4.1.1"
 			},
 			"dependencies": {
@@ -520,6 +492,16 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
 			"integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
 		},
+		"babel-plugin-transform-async-to-generator": {
+			"version": "6.16.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz",
+			"integrity": "sha1-Gew2yxSGtZ+fRorfpCzhOQjKKZk=",
+			"requires": {
+				"babel-helper-remap-async-to-generator": "6.24.1",
+				"babel-plugin-syntax-async-functions": "6.13.0",
+				"babel-runtime": "6.26.0"
+			}
+		},
 		"babel-plugin-transform-class-properties": {
 			"version": "6.24.1",
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
@@ -527,8 +509,8 @@
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
 				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -536,7 +518,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -544,18 +526,18 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-			"integrity": "sha1-dsKV3DpHQbFmWt/TFnIV3P8ypXY=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
+			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
 				"lodash": "4.17.4"
 			}
 		},
@@ -564,15 +546,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "6.24.1",
+				"babel-helper-define-map": "6.26.0",
 				"babel-helper-function-name": "6.24.1",
 				"babel-helper-optimise-call-expression": "6.24.1",
 				"babel-helper-replace-supers": "6.24.1",
 				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -580,8 +562,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -589,7 +571,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -597,7 +579,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -606,8 +588,8 @@
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
 				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -615,18 +597,18 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-			"integrity": "sha1-0+MQtA72ZKNmIiAAl8bUQCmPK/4=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"requires": {
 				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -635,7 +617,7 @@
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"requires": {
 				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -645,10 +627,10 @@
 			"requires": {
 				"babel-helper-call-delegate": "6.24.1",
 				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -656,8 +638,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -665,7 +647,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -673,9 +655,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -683,7 +665,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -691,8 +673,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"requires": {
-				"babel-helper-regex": "6.24.1",
-				"babel-runtime": "6.25.0",
+				"babel-helper-regex": "6.26.0",
+				"babel-runtime": "6.26.0",
 				"regexpu-core": "2.0.0"
 			}
 		},
@@ -701,7 +683,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
 			"integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-es3-property-literals": {
@@ -709,7 +691,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
 			"integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -718,7 +700,7 @@
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
 				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-assign": {
@@ -726,16 +708,16 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-assign/-/babel-plugin-transform-object-assign-6.22.0.tgz",
 			"integrity": "sha1-+Z0vZvGgsNSY40bFNZaEdAyqILo=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-			"integrity": "sha1-h11ryb52HFiirj/u5dxIldjH+SE=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
+			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
 				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-display-name": {
@@ -743,7 +725,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
 			"integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
 			"requires": {
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx": {
@@ -751,9 +733,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
 			"integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
 			"requires": {
-				"babel-helper-builder-react-jsx": "6.24.1",
+				"babel-helper-builder-react-jsx": "6.26.0",
 				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-react-jsx-source": {
@@ -762,15 +744,15 @@
 			"integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
 			"requires": {
 				"babel-plugin-syntax-jsx": "6.18.0",
-				"babel-runtime": "6.25.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-			"integrity": "sha1-uNowWtQ8PJm0hI5P5AN7dw0jxBg=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
+			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "0.9.11"
+				"regenerator-transform": "0.10.1"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -778,24 +760,24 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0"
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0"
 			}
 		},
 		"babel-polyfill": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-			"integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+			"integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"core-js": "2.4.1",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.1",
 				"regenerator-runtime": "0.10.5"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
 				},
 				"regenerator-runtime": {
 					"version": "0.10.5",
@@ -811,7 +793,7 @@
 			"requires": {
 				"babel-plugin-transform-es2015-destructuring": "6.23.0",
 				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-plugin-transform-es2015-parameters": "6.24.1",
 				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
 				"babel-plugin-transform-es2015-spread": "6.22.0",
@@ -834,14 +816,14 @@
 				"babel-plugin-transform-class-properties": "6.24.1",
 				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
 				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
 				"babel-plugin-transform-es2015-classes": "6.24.1",
 				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
 				"babel-plugin-transform-es2015-destructuring": "6.23.0",
 				"babel-plugin-transform-es2015-for-of": "6.23.0",
 				"babel-plugin-transform-es2015-function-name": "6.24.1",
 				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-plugin-transform-es2015-object-super": "6.24.1",
 				"babel-plugin-transform-es2015-parameters": "6.24.1",
 				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
@@ -850,7 +832,7 @@
 				"babel-plugin-transform-es3-member-expression-literals": "6.22.0",
 				"babel-plugin-transform-es3-property-literals": "6.22.0",
 				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-plugin-transform-object-rest-spread": "6.23.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
 				"babel-plugin-transform-react-jsx": "6.24.1"
 			}
@@ -879,92 +861,92 @@
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 				"babel-plugin-transform-class-properties": "6.24.1",
 				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.24.1",
+				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
 				"babel-plugin-transform-es2015-classes": "6.24.1",
 				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
 				"babel-plugin-transform-es2015-destructuring": "6.23.0",
 				"babel-plugin-transform-es2015-for-of": "6.23.0",
 				"babel-plugin-transform-es2015-function-name": "6.24.1",
 				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 				"babel-plugin-transform-es2015-parameters": "6.24.1",
 				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
 				"babel-plugin-transform-es2015-spread": "6.22.0",
 				"babel-plugin-transform-es2015-template-literals": "6.22.0",
 				"babel-plugin-transform-flow-strip-types": "6.22.0",
 				"babel-plugin-transform-object-assign": "6.22.0",
-				"babel-plugin-transform-object-rest-spread": "6.23.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
 				"babel-plugin-transform-react-display-name": "6.25.0",
 				"babel-plugin-transform-react-jsx": "6.24.1",
 				"babel-plugin-transform-react-jsx-source": "6.22.0",
-				"babel-plugin-transform-regenerator": "6.24.1",
+				"babel-plugin-transform-regenerator": "6.26.0",
 				"react-transform-hmr": "1.0.4"
 			}
 		},
 		"babel-register": {
-			"version": "6.24.1",
-			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-			"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "6.25.0",
-				"babel-runtime": "6.25.0",
-				"core-js": "2.4.1",
+				"babel-core": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.1",
 				"home-or-tmp": "2.0.0",
 				"lodash": "4.17.4",
 				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.15"
+				"source-map-support": "0.4.17"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
 				}
 			}
 		},
 		"babel-runtime": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-			"integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.4.1",
-				"regenerator-runtime": "0.10.5"
+				"core-js": "2.5.1",
+				"regenerator-runtime": "0.11.0"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
 				},
 				"regenerator-runtime": {
-					"version": "0.10.5",
-					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-					"integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+					"version": "0.11.0",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
+					"integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
 				}
 			}
 		},
 		"babel-template": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-			"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
 				"lodash": "4.17.4"
 			}
 		},
 		"babel-traverse": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-			"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "6.22.0",
+				"babel-code-frame": "6.26.0",
 				"babel-messages": "6.23.0",
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
 				"debug": "2.6.8",
 				"globals": "9.18.0",
 				"invariant": "2.2.2",
@@ -972,20 +954,20 @@
 			}
 		},
 		"babel-types": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-			"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "6.25.0",
+				"babel-runtime": "6.26.0",
 				"esutils": "2.0.2",
 				"lodash": "4.17.4",
 				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
-			"version": "6.17.4",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz",
-			"integrity": "sha512-kChlV+0SXkjE0vUn9OZ7pBMWRFd8uq3mZe8x1K6jhuNcAFAtEnjchFAqB+dYEXKyd+JpT6eppRR78QAr5gTsUw=="
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+			"integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1030,6 +1012,11 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
 			"integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
+		},
+		"big-integer": {
+			"version": "1.6.25",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
+			"integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM="
 		},
 		"body-parser": {
 			"version": "1.13.3",
@@ -1077,17 +1064,20 @@
 			}
 		},
 		"bplist-creator": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.4.tgz",
-			"integrity": "sha1-SsBJZ4LhJ6hcHSAmpPXrIqev+ZE=",
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.7.tgz",
+			"integrity": "sha1-N98VNgkoJLh8QvlXsBNEEXNyrkU=",
 			"requires": {
-				"stream-buffers": "0.2.6"
+				"stream-buffers": "2.2.0"
 			}
 		},
 		"bplist-parser": {
-			"version": "0.0.6",
-			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.0.6.tgz",
-			"integrity": "sha1-ONo0cYF9+dRKs4kuJ3B7u9daEbk="
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
+			"integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
+			"requires": {
+				"big-integer": "1.6.25"
+			}
 		},
 		"brace-expansion": {
 			"version": "1.1.8",
@@ -1102,7 +1092,6 @@
 			"version": "1.8.5",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"dev": true,
 			"requires": {
 				"expand-range": "1.8.2",
 				"preserve": "0.2.0",
@@ -1182,23 +1171,23 @@
 			}
 		},
 		"ci-info": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-			"integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+			"integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
 			"dev": true
 		},
 		"cli-cursor": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+			"integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
 			"requires": {
-				"restore-cursor": "1.0.1"
+				"restore-cursor": "2.0.0"
 			}
 		},
 		"cli-width": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-			"integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+			"integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
 		},
 		"cliui": {
 			"version": "2.1.0",
@@ -1241,7 +1230,6 @@
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -1249,8 +1237,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"combined-stream": {
 			"version": "1.0.5",
@@ -1270,7 +1257,7 @@
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
 			"integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
 			"requires": {
-				"mime-db": "1.29.0"
+				"mime-db": "1.30.0"
 			}
 		},
 		"compression": {
@@ -1305,6 +1292,16 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+		},
+		"concat-stream": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"requires": {
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.3",
+				"typedarray": "0.0.6"
+			}
 		},
 		"connect": {
 			"version": "2.30.2",
@@ -1434,6 +1431,16 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz",
 			"integrity": "sha1-+mIuG8OIvyVzCQgta2UgDOZwkLo="
+		},
+		"create-react-class": {
+			"version": "15.6.0",
+			"resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+			"integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
+			"requires": {
+				"fbjs": "0.8.15",
+				"loose-envify": "1.3.1",
+				"object-assign": "4.1.1"
+			}
 		},
 		"cross-spawn": {
 			"version": "3.0.1",
@@ -1570,9 +1577,9 @@
 			}
 		},
 		"diff": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-			"integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+			"integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
 			"dev": true
 		},
 		"dom-walk": {
@@ -1586,6 +1593,29 @@
 			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
 			"requires": {
 				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
 			}
 		},
 		"ecc-jsbn": {
@@ -1610,6 +1640,16 @@
 				"iconv-lite": "0.4.18"
 			}
 		},
+		"envinfo": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.4.1.tgz",
+			"integrity": "sha1-jIDp8u7CzU4q2yxdASfOB6Kqoq4=",
+			"requires": {
+				"minimist": "1.2.0",
+				"os-name": "2.0.1",
+				"which": "1.3.0"
+			}
+		},
 		"errno": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
@@ -1631,17 +1671,25 @@
 			"resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.3.tgz",
 			"integrity": "sha1-t7cO2PNZ6duICS8tIMD4MUIK2D8=",
 			"requires": {
-				"accepts": "1.3.3",
+				"accepts": "1.3.4",
 				"escape-html": "1.0.3"
 			},
 			"dependencies": {
 				"accepts": {
-					"version": "1.3.3",
-					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-					"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+					"version": "1.3.4",
+					"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+					"integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
 					"requires": {
-						"mime-types": "2.1.11",
+						"mime-types": "2.1.17",
 						"negotiator": "0.6.1"
+					}
+				},
+				"mime-types": {
+					"version": "2.1.17",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+					"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+					"requires": {
+						"mime-db": "1.30.0"
 					}
 				},
 				"negotiator": {
@@ -1662,33 +1710,23 @@
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+			"integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
 			"dev": true,
 			"requires": {
-				"esprima": "2.7.3",
-				"estraverse": "1.9.3",
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
 				"esutils": "2.0.2",
 				"optionator": "0.8.2",
-				"source-map": "0.2.0"
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"esprima": {
-					"version": "2.7.3",
-					"resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-					"integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
 					"dev": true
-				},
-				"source-map": {
-					"version": "0.2.0",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"amdefine": "1.0.1"
-					}
 				}
 			}
 		},
@@ -1699,9 +1737,9 @@
 			"dev": true
 		},
 		"estraverse": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-			"integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+			"integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
 			"dev": true
 		},
 		"esutils": {
@@ -1720,23 +1758,17 @@
 			"integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
 		},
 		"exec-sh": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-			"integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"requires": {
 				"merge": "1.2.0"
 			}
-		},
-		"exit-hook": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
-			"integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g="
 		},
 		"expand-brackets": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"dev": true,
 			"requires": {
 				"is-posix-bracket": "0.1.1"
 			}
@@ -1745,7 +1777,6 @@
 			"version": "1.8.2",
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true,
 			"requires": {
 				"fill-range": "2.2.3"
 			}
@@ -1794,11 +1825,20 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
+		"external-editor": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.0.4.tgz",
+			"integrity": "sha1-HtkZnanL/i7y96MbL96LDRI2iXI=",
+			"requires": {
+				"iconv-lite": "0.4.18",
+				"jschardet": "1.5.1",
+				"tmp": "0.0.31"
+			}
+		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -1824,17 +1864,17 @@
 			"dev": true
 		},
 		"fb-watchman": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
-			"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
+			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"requires": {
-				"bser": "1.0.2"
+				"bser": "2.0.0"
 			},
 			"dependencies": {
 				"bser": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
+					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 					"requires": {
 						"node-int64": "0.4.0"
 					}
@@ -1842,9 +1882,9 @@
 			}
 		},
 		"fbjs": {
-			"version": "0.8.14",
-			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
-			"integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+			"version": "0.8.15",
+			"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
+			"integrity": "sha1-TwaV/fzBbDfAsH+s7Iy0xAkWhbk=",
 			"requires": {
 				"core-js": "1.2.7",
 				"isomorphic-fetch": "2.2.1",
@@ -1860,7 +1900,7 @@
 			"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.7.1.tgz",
 			"integrity": "sha1-TxFeIY4kPjrdvw7dqsHjxi9wP6w=",
 			"requires": {
-				"babel-core": "6.25.0",
+				"babel-core": "6.26.0",
 				"babel-preset-fbjs": "1.0.0",
 				"core-js": "1.2.7",
 				"cross-spawn": "3.0.1",
@@ -1882,13 +1922,13 @@
 						"babel-plugin-transform-class-properties": "6.24.1",
 						"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
 						"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-						"babel-plugin-transform-es2015-block-scoping": "6.24.1",
+						"babel-plugin-transform-es2015-block-scoping": "6.26.0",
 						"babel-plugin-transform-es2015-classes": "6.24.1",
 						"babel-plugin-transform-es2015-computed-properties": "6.24.1",
 						"babel-plugin-transform-es2015-destructuring": "6.23.0",
 						"babel-plugin-transform-es2015-for-of": "6.23.0",
 						"babel-plugin-transform-es2015-literals": "6.22.0",
-						"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 						"babel-plugin-transform-es2015-object-super": "6.24.1",
 						"babel-plugin-transform-es2015-parameters": "6.24.1",
 						"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
@@ -1897,26 +1937,24 @@
 						"babel-plugin-transform-es3-member-expression-literals": "6.22.0",
 						"babel-plugin-transform-es3-property-literals": "6.22.0",
 						"babel-plugin-transform-flow-strip-types": "6.22.0",
-						"babel-plugin-transform-object-rest-spread": "6.23.0",
+						"babel-plugin-transform-object-rest-spread": "6.26.0",
 						"object-assign": "4.1.1"
 					}
 				}
 			}
 		},
 		"figures": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
 			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
+				"escape-string-regexp": "1.0.5"
 			}
 		},
 		"filename-regex": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-			"dev": true
+			"integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
 		},
 		"fileset": {
 			"version": "2.0.3",
@@ -1926,29 +1964,12 @@
 			"requires": {
 				"glob": "7.1.2",
 				"minimatch": "3.0.4"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				}
 			}
 		},
 		"fill-range": {
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-			"dev": true,
 			"requires": {
 				"is-number": "2.1.0",
 				"isobject": "2.1.0",
@@ -2000,14 +2021,12 @@
 		"for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-			"dev": true
+			"integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
 		},
 		"for-own": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true,
 			"requires": {
 				"for-in": "1.0.2"
 			}
@@ -2018,21 +2037,21 @@
 			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-			"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 			"requires": {
 				"asynckit": "0.4.0",
 				"combined-stream": "1.0.5",
-				"mime-types": "2.1.16"
+				"mime-types": "2.1.17"
 			},
 			"dependencies": {
 				"mime-types": {
-					"version": "2.1.16",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-					"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+					"version": "2.1.17",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+					"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 					"requires": {
-						"mime-db": "1.29.0"
+						"mime-db": "1.30.0"
 					}
 				}
 			}
@@ -2043,21 +2062,804 @@
 			"integrity": "sha1-ZR+DjiJCTnVm3hYdg1jKoZn4PU8="
 		},
 		"fs-extra": {
-			"version": "0.26.7",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-			"integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+			"integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
 			"requires": {
 				"graceful-fs": "4.1.11",
 				"jsonfile": "2.4.0",
-				"klaw": "1.3.1",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.6.1"
+				"klaw": "1.3.1"
 			}
 		},
 		"fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+		},
+		"fsevents": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+			"integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+			"optional": true,
+			"requires": {
+				"nan": "2.7.0",
+				"node-pre-gyp": "0.6.36"
+			},
+			"dependencies": {
+				"abbrev": {
+					"version": "1.1.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ajv": {
+					"version": "4.11.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"co": "4.6.0",
+						"json-stable-stringify": "1.0.1"
+					}
+				},
+				"ansi-regex": {
+					"version": "2.1.1",
+					"bundled": true
+				},
+				"aproba": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"are-we-there-yet": {
+					"version": "1.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"delegates": "1.0.0",
+						"readable-stream": "2.2.9"
+					}
+				},
+				"asn1": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"assert-plus": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"asynckit": {
+					"version": "0.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws-sign2": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"aws4": {
+					"version": "1.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"balanced-match": {
+					"version": "0.4.2",
+					"bundled": true
+				},
+				"bcrypt-pbkdf": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"tweetnacl": "0.14.5"
+					}
+				},
+				"block-stream": {
+					"version": "0.0.9",
+					"bundled": true,
+					"requires": {
+						"inherits": "2.0.3"
+					}
+				},
+				"boom": {
+					"version": "2.10.1",
+					"bundled": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"brace-expansion": {
+					"version": "1.1.7",
+					"bundled": true,
+					"requires": {
+						"balanced-match": "0.4.2",
+						"concat-map": "0.0.1"
+					}
+				},
+				"buffer-shims": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"caseless": {
+					"version": "0.12.0",
+					"bundled": true,
+					"optional": true
+				},
+				"co": {
+					"version": "4.6.0",
+					"bundled": true,
+					"optional": true
+				},
+				"code-point-at": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"combined-stream": {
+					"version": "1.0.5",
+					"bundled": true,
+					"requires": {
+						"delayed-stream": "1.0.0"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"bundled": true
+				},
+				"console-control-strings": {
+					"version": "1.1.0",
+					"bundled": true
+				},
+				"core-util-is": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"cryptiles": {
+					"version": "2.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1"
+					}
+				},
+				"dashdash": {
+					"version": "1.14.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"debug": {
+					"version": "2.6.8",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"deep-extend": {
+					"version": "0.4.2",
+					"bundled": true,
+					"optional": true
+				},
+				"delayed-stream": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"delegates": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"ecc-jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"extend": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"extsprintf": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"forever-agent": {
+					"version": "0.6.1",
+					"bundled": true,
+					"optional": true
+				},
+				"form-data": {
+					"version": "2.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.15"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"fstream": {
+					"version": "1.0.11",
+					"bundled": true,
+					"requires": {
+						"graceful-fs": "4.1.11",
+						"inherits": "2.0.3",
+						"mkdirp": "0.5.1",
+						"rimraf": "2.6.1"
+					}
+				},
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"fstream": "1.0.11",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4"
+					}
+				},
+				"gauge": {
+					"version": "2.7.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aproba": "1.1.1",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
+					}
+				},
+				"getpass": {
+					"version": "0.1.7",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"glob": {
+					"version": "7.1.2",
+					"bundled": true,
+					"requires": {
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
+					}
+				},
+				"graceful-fs": {
+					"version": "4.1.11",
+					"bundled": true
+				},
+				"har-schema": {
+					"version": "1.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"har-validator": {
+					"version": "4.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"ajv": "4.11.8",
+						"har-schema": "1.0.5"
+					}
+				},
+				"has-unicode": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"hawk": {
+					"version": "3.1.3",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"boom": "2.10.1",
+						"cryptiles": "2.0.5",
+						"hoek": "2.16.3",
+						"sntp": "1.0.9"
+					}
+				},
+				"hoek": {
+					"version": "2.16.3",
+					"bundled": true
+				},
+				"http-signature": {
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "0.2.0",
+						"jsprim": "1.4.0",
+						"sshpk": "1.13.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"bundled": true,
+					"requires": {
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
+					}
+				},
+				"inherits": {
+					"version": "2.0.3",
+					"bundled": true
+				},
+				"ini": {
+					"version": "1.3.4",
+					"bundled": true,
+					"optional": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"bundled": true,
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"bundled": true
+				},
+				"isstream": {
+					"version": "0.1.2",
+					"bundled": true,
+					"optional": true
+				},
+				"jodid25519": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsbn": "0.1.1"
+					}
+				},
+				"jsbn": {
+					"version": "0.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"json-schema": {
+					"version": "0.2.3",
+					"bundled": true,
+					"optional": true
+				},
+				"json-stable-stringify": {
+					"version": "1.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"jsonify": "0.0.0"
+					}
+				},
+				"json-stringify-safe": {
+					"version": "5.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"jsonify": {
+					"version": "0.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"jsprim": {
+					"version": "1.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"assert-plus": "1.0.0",
+						"extsprintf": "1.0.2",
+						"json-schema": "0.2.3",
+						"verror": "1.3.6"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"mime-db": {
+					"version": "1.27.0",
+					"bundled": true
+				},
+				"mime-types": {
+					"version": "2.1.15",
+					"bundled": true,
+					"requires": {
+						"mime-db": "1.27.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"bundled": true,
+					"requires": {
+						"brace-expansion": "1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "0.0.8",
+					"bundled": true
+				},
+				"mkdirp": {
+					"version": "0.5.1",
+					"bundled": true,
+					"requires": {
+						"minimist": "0.0.8"
+					}
+				},
+				"ms": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"node-pre-gyp": {
+					"version": "0.6.36",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"mkdirp": "0.5.1",
+						"nopt": "4.0.1",
+						"npmlog": "4.1.0",
+						"rc": "1.2.1",
+						"request": "2.81.0",
+						"rimraf": "2.6.1",
+						"semver": "5.3.0",
+						"tar": "2.2.1",
+						"tar-pack": "3.4.0"
+					}
+				},
+				"nopt": {
+					"version": "4.0.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"abbrev": "1.1.0",
+						"osenv": "0.1.4"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
+					}
+				},
+				"number-is-nan": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"oauth-sign": {
+					"version": "0.8.2",
+					"bundled": true,
+					"optional": true
+				},
+				"object-assign": {
+					"version": "4.1.1",
+					"bundled": true,
+					"optional": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"bundled": true,
+					"requires": {
+						"wrappy": "1.0.2"
+					}
+				},
+				"os-homedir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"os-tmpdir": {
+					"version": "1.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"osenv": {
+					"version": "0.1.4",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"bundled": true
+				},
+				"performance-now": {
+					"version": "0.2.0",
+					"bundled": true,
+					"optional": true
+				},
+				"process-nextick-args": {
+					"version": "1.0.7",
+					"bundled": true
+				},
+				"punycode": {
+					"version": "1.4.1",
+					"bundled": true,
+					"optional": true
+				},
+				"qs": {
+					"version": "6.4.0",
+					"bundled": true,
+					"optional": true
+				},
+				"rc": {
+					"version": "1.2.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"deep-extend": "0.4.2",
+						"ini": "1.3.4",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
+					},
+					"dependencies": {
+						"minimist": {
+							"version": "1.2.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"readable-stream": {
+					"version": "2.2.9",
+					"bundled": true,
+					"requires": {
+						"buffer-shims": "1.0.0",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "1.0.7",
+						"string_decoder": "1.0.1",
+						"util-deprecate": "1.0.2"
+					}
+				},
+				"request": {
+					"version": "2.81.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"aws-sign2": "0.6.0",
+						"aws4": "1.6.0",
+						"caseless": "0.12.0",
+						"combined-stream": "1.0.5",
+						"extend": "3.0.1",
+						"forever-agent": "0.6.1",
+						"form-data": "2.1.4",
+						"har-validator": "4.2.1",
+						"hawk": "3.1.3",
+						"http-signature": "1.1.1",
+						"is-typedarray": "1.0.0",
+						"isstream": "0.1.2",
+						"json-stringify-safe": "5.0.1",
+						"mime-types": "2.1.15",
+						"oauth-sign": "0.8.2",
+						"performance-now": "0.2.0",
+						"qs": "6.4.0",
+						"safe-buffer": "5.0.1",
+						"stringstream": "0.0.5",
+						"tough-cookie": "2.3.2",
+						"tunnel-agent": "0.6.0",
+						"uuid": "3.0.1"
+					}
+				},
+				"rimraf": {
+					"version": "2.6.1",
+					"bundled": true,
+					"requires": {
+						"glob": "7.1.2"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.0.1",
+					"bundled": true
+				},
+				"semver": {
+					"version": "5.3.0",
+					"bundled": true,
+					"optional": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"bundled": true,
+					"optional": true
+				},
+				"signal-exit": {
+					"version": "3.0.2",
+					"bundled": true,
+					"optional": true
+				},
+				"sntp": {
+					"version": "1.0.9",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"hoek": "2.16.3"
+					}
+				},
+				"sshpk": {
+					"version": "1.13.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"asn1": "0.2.3",
+						"assert-plus": "1.0.0",
+						"bcrypt-pbkdf": "1.0.1",
+						"dashdash": "1.14.1",
+						"ecc-jsbn": "0.1.1",
+						"getpass": "0.1.7",
+						"jodid25519": "1.0.2",
+						"jsbn": "0.1.1",
+						"tweetnacl": "0.14.5"
+					},
+					"dependencies": {
+						"assert-plus": {
+							"version": "1.0.0",
+							"bundled": true,
+							"optional": true
+						}
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"bundled": true,
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.0.1",
+					"bundled": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"stringstream": {
+					"version": "0.0.5",
+					"bundled": true,
+					"optional": true
+				},
+				"strip-ansi": {
+					"version": "3.0.1",
+					"bundled": true,
+					"requires": {
+						"ansi-regex": "2.1.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"tar": {
+					"version": "2.2.1",
+					"bundled": true,
+					"requires": {
+						"block-stream": "0.0.9",
+						"fstream": "1.0.11",
+						"inherits": "2.0.3"
+					}
+				},
+				"tar-pack": {
+					"version": "3.4.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"debug": "2.6.8",
+						"fstream": "1.0.11",
+						"fstream-ignore": "1.0.5",
+						"once": "1.4.0",
+						"readable-stream": "2.2.9",
+						"rimraf": "2.6.1",
+						"tar": "2.2.1",
+						"uid-number": "0.0.6"
+					}
+				},
+				"tough-cookie": {
+					"version": "2.3.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"punycode": "1.4.1"
+					}
+				},
+				"tunnel-agent": {
+					"version": "0.6.0",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"safe-buffer": "5.0.1"
+					}
+				},
+				"tweetnacl": {
+					"version": "0.14.5",
+					"bundled": true,
+					"optional": true
+				},
+				"uid-number": {
+					"version": "0.0.6",
+					"bundled": true,
+					"optional": true
+				},
+				"util-deprecate": {
+					"version": "1.0.2",
+					"bundled": true
+				},
+				"uuid": {
+					"version": "3.0.1",
+					"bundled": true,
+					"optional": true
+				},
+				"verror": {
+					"version": "1.3.6",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"extsprintf": "1.0.2"
+					}
+				},
+				"wide-align": {
+					"version": "1.1.2",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"string-width": "1.0.2"
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"bundled": true
+				}
+			}
 		},
 		"gauge": {
 			"version": "1.2.7",
@@ -2092,10 +2894,11 @@
 			}
 		},
 		"glob": {
-			"version": "5.0.15",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"requires": {
+				"fs.realpath": "1.0.0",
 				"inflight": "1.0.6",
 				"inherits": "2.0.3",
 				"minimatch": "3.0.4",
@@ -2107,7 +2910,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true,
 			"requires": {
 				"glob-parent": "2.0.0",
 				"is-glob": "2.0.1"
@@ -2117,7 +2919,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true,
 			"requires": {
 				"is-glob": "2.0.1"
 			}
@@ -2204,7 +3005,7 @@
 				"async": "1.5.2",
 				"optimist": "0.6.1",
 				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"uglify-js": "2.7.5"
 			},
 			"dependencies": {
 				"async": {
@@ -2247,10 +3048,9 @@
 			}
 		},
 		"has-flag": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-			"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-			"dev": true
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+			"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
 		},
 		"has-gulplog": {
 			"version": "0.1.0",
@@ -2329,14 +3129,9 @@
 			"integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
 		},
 		"image-size": {
-			"version": "0.3.5",
-			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
-			"integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw="
-		},
-		"immutable": {
-			"version": "3.7.6",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-			"integrity": "sha1-E7TTyxK++hVIKib+Gy665kAHHks="
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.1.tgz",
+			"integrity": "sha512-lHMlI2MykfeHAQdtydQh4fTcBQVf4zLTA91w1euBe9rbmAfJ/iyzMh8H3KD9u1RldlHaMS3tmMV5TEe9BkmW9g=="
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
@@ -2358,23 +3153,65 @@
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
 		},
 		"inquirer": {
-			"version": "0.12.0",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
+			"integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"ansi-regex": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-width": "2.1.0",
-				"figures": "1.7.0",
+				"ansi-escapes": "2.0.0",
+				"chalk": "2.1.0",
+				"cli-cursor": "2.1.0",
+				"cli-width": "2.2.0",
+				"external-editor": "2.0.4",
+				"figures": "2.0.0",
 				"lodash": "4.17.4",
-				"readline2": "1.0.1",
-				"run-async": "0.1.0",
-				"rx-lite": "3.1.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
+				"mute-stream": "0.0.7",
+				"run-async": "2.3.0",
+				"rx-lite": "4.0.8",
+				"rx-lite-aggregates": "4.0.8",
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
 				"through": "2.3.8"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
+					"integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+					"requires": {
+						"ansi-styles": "3.2.0",
+						"escape-string-regexp": "1.0.5",
+						"supports-color": "4.4.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				},
+				"supports-color": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+					"requires": {
+						"has-flag": "2.0.0"
+					}
+				}
 			}
 		},
 		"invariant": {
@@ -2414,20 +3251,18 @@
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
 			"dev": true,
 			"requires": {
-				"ci-info": "1.0.0"
+				"ci-info": "1.1.1"
 			}
 		},
 		"is-dotfile": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-			"dev": true
+			"integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
 		},
 		"is-equal-shallow": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true,
 			"requires": {
 				"is-primitive": "2.0.0"
 			}
@@ -2435,14 +3270,12 @@
 		"is-extendable": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-			"dev": true
+			"integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
 		},
 		"is-extglob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-			"dev": true
+			"integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -2453,18 +3286,14 @@
 			}
 		},
 		"is-fullwidth-code-point": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"requires": {
-				"number-is-nan": "1.0.1"
-			}
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+			"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true,
 			"requires": {
 				"is-extglob": "1.0.0"
 			}
@@ -2473,7 +3302,6 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true,
 			"requires": {
 				"kind-of": "3.2.2"
 			}
@@ -2481,14 +3309,17 @@
 		"is-posix-bracket": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-			"dev": true
+			"integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
 		},
 		"is-primitive": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-			"dev": true
+			"integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
+		},
+		"is-promise": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -2506,14 +3337,9 @@
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
 		},
 		"isarray": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-		},
-		"isemail": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-			"integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo="
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -2524,17 +3350,8 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 			"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-			"dev": true,
 			"requires": {
 				"isarray": "1.0.0"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-					"dev": true
-				}
 			}
 		},
 		"isomorphic-fetch": {
@@ -2542,7 +3359,7 @@
 			"resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
 			"integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
 			"requires": {
-				"node-fetch": "1.7.1",
+				"node-fetch": "1.7.3",
 				"whatwg-fetch": "2.0.3"
 			}
 		},
@@ -2552,19 +3369,19 @@
 			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-api": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.11.tgz",
-			"integrity": "sha1-/MC0YeKzvaceMFFVE4I4doJX2d4=",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
+			"integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
 			"dev": true,
 			"requires": {
 				"async": "2.5.0",
 				"fileset": "2.0.3",
 				"istanbul-lib-coverage": "1.1.1",
 				"istanbul-lib-hook": "1.0.7",
-				"istanbul-lib-instrument": "1.7.4",
+				"istanbul-lib-instrument": "1.8.0",
 				"istanbul-lib-report": "1.1.1",
 				"istanbul-lib-source-maps": "1.2.1",
-				"istanbul-reports": "1.1.1",
+				"istanbul-reports": "1.1.2",
 				"js-yaml": "3.9.1",
 				"mkdirp": "0.5.1",
 				"once": "1.4.0"
@@ -2586,16 +3403,16 @@
 			}
 		},
 		"istanbul-lib-instrument": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz",
-			"integrity": "sha1-6f2SDkdn89Ge3HZeLWs/XMvQ7qg=",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
+			"integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
 			"dev": true,
 			"requires": {
-				"babel-generator": "6.25.0",
-				"babel-template": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
+				"babel-generator": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
 				"istanbul-lib-coverage": "1.1.1",
 				"semver": "5.4.1"
 			}
@@ -2612,6 +3429,12 @@
 				"supports-color": "3.2.3"
 			},
 			"dependencies": {
+				"has-flag": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+					"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+					"dev": true
+				},
 				"supports-color": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
@@ -2633,13 +3456,13 @@
 				"istanbul-lib-coverage": "1.1.1",
 				"mkdirp": "0.5.1",
 				"rimraf": "2.6.1",
-				"source-map": "0.5.6"
+				"source-map": "0.5.7"
 			}
 		},
 		"istanbul-reports": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
-			"integrity": "sha512-P8G873A0kW24XRlxHVGhMJBhQ8gWAec+dae7ZxOBzxT4w+a9ATSPvRVK3LB1RAJ9S8bg2tOyWHAGW40Zd2dKfw==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha1-D7Lj9qqZIr085F0F2KtNXo4HvU8=",
 			"dev": true,
 			"requires": {
 				"handlebars": "4.0.10"
@@ -2654,22 +3477,19 @@
 				"jest-cli": "19.0.2"
 			},
 			"dependencies": {
+				"ansi-escapes": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+					"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+					"dev": true
+				},
 				"bser": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
 					"dev": true,
 					"requires": {
 						"node-int64": "0.4.0"
-					}
-				},
-				"fb-watchman": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-					"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-					"dev": true,
-					"requires": {
-						"bser": "2.0.0"
 					}
 				},
 				"jest-cli": {
@@ -2683,9 +3503,9 @@
 						"chalk": "1.1.3",
 						"graceful-fs": "4.1.11",
 						"is-ci": "1.0.10",
-						"istanbul-api": "1.1.11",
+						"istanbul-api": "1.1.14",
 						"istanbul-lib-coverage": "1.1.1",
-						"istanbul-lib-instrument": "1.7.4",
+						"istanbul-lib-instrument": "1.8.0",
 						"jest-changed-files": "19.0.2",
 						"jest-config": "19.0.4",
 						"jest-environment-jsdom": "19.0.2",
@@ -2703,7 +3523,7 @@
 						"string-length": "1.0.1",
 						"throat": "3.2.0",
 						"which": "1.3.0",
-						"worker-farm": "1.4.1",
+						"worker-farm": "1.5.0",
 						"yargs": "6.6.0"
 					}
 				},
@@ -2717,7 +3537,7 @@
 						"graceful-fs": "4.1.11",
 						"micromatch": "2.3.11",
 						"sane": "1.5.0",
-						"worker-farm": "1.4.1"
+						"worker-farm": "1.5.0"
 					}
 				},
 				"sane": {
@@ -2727,7 +3547,7 @@
 					"dev": true,
 					"requires": {
 						"anymatch": "1.3.2",
-						"exec-sh": "0.2.0",
+						"exec-sh": "0.2.1",
 						"fb-watchman": "1.9.2",
 						"minimatch": "3.0.4",
 						"minimist": "1.2.0",
@@ -2735,15 +3555,6 @@
 						"watch": "0.10.0"
 					},
 					"dependencies": {
-						"bser": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-							"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-							"dev": true,
-							"requires": {
-								"node-int64": "0.4.0"
-							}
-						},
 						"fb-watchman": {
 							"version": "1.9.2",
 							"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
@@ -2754,6 +3565,12 @@
 							}
 						}
 					}
+				},
+				"throat": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+					"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+					"dev": true
 				}
 			}
 		},
@@ -2777,6 +3594,26 @@
 				"jest-resolve": "19.0.2",
 				"jest-validate": "19.0.2",
 				"pretty-format": "19.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "19.0.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+					"integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0"
+					}
+				}
 			}
 		},
 		"jest-diff": {
@@ -2786,10 +3623,35 @@
 			"dev": true,
 			"requires": {
 				"chalk": "1.1.3",
-				"diff": "3.3.0",
+				"diff": "3.3.1",
 				"jest-matcher-utils": "19.0.0",
 				"pretty-format": "19.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "19.0.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+					"integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0"
+					}
+				}
 			}
+		},
+		"jest-docblock": {
+			"version": "20.1.0-delta.4",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.1.0-delta.4.tgz",
+			"integrity": "sha512-apbBKyQ8ET8XQbOnsjIYTvmo2+FRZIsxUkfy75IbG+SH9ILQLjEfPXq3B/iMRCGoTAeI8lwxUQoLKGbw0mrTCQ=="
 		},
 		"jest-environment-jsdom": {
 			"version": "19.0.2",
@@ -2819,15 +3681,33 @@
 			"dev": true
 		},
 		"jest-haste-map": {
-			"version": "18.0.0",
-			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-18.0.0.tgz",
-			"integrity": "sha1-cH07WuO8valxw56LkR0grYUCx0g=",
+			"version": "20.1.0-delta.4",
+			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.1.0-delta.4.tgz",
+			"integrity": "sha512-L95f3nYoxUSzqzJdOq39ggklspwkqOq/FkzvH0SYhXdpv0c0kW8DXLovxfZy5FnK4rUyeVMBI9aNQ+TvZHKT3Q==",
 			"requires": {
-				"fb-watchman": "1.9.2",
+				"fb-watchman": "2.0.0",
 				"graceful-fs": "4.1.11",
-				"multimatch": "2.1.0",
-				"sane": "1.4.1",
-				"worker-farm": "1.4.1"
+				"jest-docblock": "20.1.0-delta.4",
+				"micromatch": "2.3.11",
+				"sane": "2.0.0",
+				"worker-farm": "1.5.0"
+			},
+			"dependencies": {
+				"sane": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-2.0.0.tgz",
+					"integrity": "sha1-mct58h9KU6adTQzZV8LbBAJLjrI=",
+					"requires": {
+						"anymatch": "1.3.2",
+						"exec-sh": "0.2.1",
+						"fb-watchman": "2.0.0",
+						"fsevents": "1.1.2",
+						"minimatch": "3.0.4",
+						"minimist": "1.2.0",
+						"walker": "1.0.7",
+						"watch": "0.10.0"
+					}
+				}
 			}
 		},
 		"jest-jasmine2": {
@@ -2851,6 +3731,26 @@
 			"requires": {
 				"chalk": "1.1.3",
 				"pretty-format": "19.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "19.0.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+					"integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0"
+					}
+				}
 			}
 		},
 		"jest-matchers": {
@@ -2899,21 +3799,12 @@
 			},
 			"dependencies": {
 				"bser": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
 					"dev": true,
 					"requires": {
 						"node-int64": "0.4.0"
-					}
-				},
-				"fb-watchman": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-					"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-					"dev": true,
-					"requires": {
-						"bser": "2.0.0"
 					}
 				},
 				"jest-haste-map": {
@@ -2926,7 +3817,7 @@
 						"graceful-fs": "4.1.11",
 						"micromatch": "2.3.11",
 						"sane": "1.5.0",
-						"worker-farm": "1.4.1"
+						"worker-farm": "1.5.0"
 					}
 				},
 				"sane": {
@@ -2936,7 +3827,7 @@
 					"dev": true,
 					"requires": {
 						"anymatch": "1.3.2",
-						"exec-sh": "0.2.0",
+						"exec-sh": "0.2.1",
 						"fb-watchman": "1.9.2",
 						"minimatch": "3.0.4",
 						"minimist": "1.2.0",
@@ -2944,15 +3835,6 @@
 						"watch": "0.10.0"
 					},
 					"dependencies": {
-						"bser": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-							"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-							"dev": true,
-							"requires": {
-								"node-int64": "0.4.0"
-							}
-						},
 						"fb-watchman": {
 							"version": "1.9.2",
 							"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
@@ -2981,7 +3863,7 @@
 			"integrity": "sha1-8WfZ8TR3UvICc2EGeSZIU0n8wkU=",
 			"dev": true,
 			"requires": {
-				"babel-core": "6.25.0",
+				"babel-core": "6.26.0",
 				"babel-jest": "19.0.0",
 				"babel-plugin-istanbul": "4.1.4",
 				"chalk": "1.1.3",
@@ -2999,21 +3881,12 @@
 			},
 			"dependencies": {
 				"bser": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
-					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
 					"dev": true,
 					"requires": {
 						"node-int64": "0.4.0"
-					}
-				},
-				"fb-watchman": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-					"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
-					"dev": true,
-					"requires": {
-						"bser": "2.0.0"
 					}
 				},
 				"jest-haste-map": {
@@ -3026,7 +3899,7 @@
 						"graceful-fs": "4.1.11",
 						"micromatch": "2.3.11",
 						"sane": "1.5.0",
-						"worker-farm": "1.4.1"
+						"worker-farm": "1.5.0"
 					}
 				},
 				"sane": {
@@ -3036,7 +3909,7 @@
 					"dev": true,
 					"requires": {
 						"anymatch": "1.3.2",
-						"exec-sh": "0.2.0",
+						"exec-sh": "0.2.1",
 						"fb-watchman": "1.9.2",
 						"minimatch": "3.0.4",
 						"minimist": "1.2.0",
@@ -3044,15 +3917,6 @@
 						"watch": "0.10.0"
 					},
 					"dependencies": {
-						"bser": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-							"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-							"dev": true,
-							"requires": {
-								"node-int64": "0.4.0"
-							}
-						},
 						"fb-watchman": {
 							"version": "1.9.2",
 							"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
@@ -3085,6 +3949,26 @@
 				"jest-util": "19.0.2",
 				"natural-compare": "1.4.0",
 				"pretty-format": "19.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "19.0.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+					"integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0"
+					}
+				}
 			}
 		},
 		"jest-util": {
@@ -3113,17 +3997,26 @@
 				"jest-matcher-utils": "19.0.0",
 				"leven": "2.1.0",
 				"pretty-format": "19.0.0"
-			}
-		},
-		"joi": {
-			"version": "6.10.1",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-			"integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-			"requires": {
-				"hoek": "2.16.3",
-				"isemail": "1.2.0",
-				"moment": "2.18.1",
-				"topo": "1.1.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"dev": true,
+					"requires": {
+						"color-convert": "1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "19.0.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
+					"integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "3.2.0"
+					}
+				}
 			}
 		},
 		"js-tokens": {
@@ -3147,6 +4040,11 @@
 			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
 			"optional": true
 		},
+		"jschardet": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
+			"integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A=="
+		},
 		"jsdom": {
 			"version": "9.12.0",
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
@@ -3160,7 +4058,7 @@
 				"content-type-parser": "1.0.1",
 				"cssom": "0.3.2",
 				"cssstyle": "0.2.37",
-				"escodegen": "1.8.1",
+				"escodegen": "1.9.0",
 				"html-encoding-sniffer": "1.0.1",
 				"nwmatcher": "1.4.1",
 				"parse5": "1.5.1",
@@ -3168,7 +4066,7 @@
 				"sax": "1.2.4",
 				"symbol-tree": "3.2.2",
 				"tough-cookie": "2.3.2",
-				"webidl-conversions": "4.0.1",
+				"webidl-conversions": "4.0.2",
 				"whatwg-encoding": "1.0.1",
 				"whatwg-url": "4.8.0",
 				"xml-name-validator": "2.0.1"
@@ -3466,6 +4364,11 @@
 				"yallist": "2.1.2"
 			}
 		},
+		"macos-release": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+			"integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+		},
 		"makeerror": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -3483,6 +4386,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
 			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
+		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"requires": {
+				"readable-stream": "2.3.3"
+			}
 		},
 		"method-override": {
 			"version": "2.3.9",
@@ -3507,11 +4418,149 @@
 			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
 			"integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
 		},
+		"metro-bundler": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/metro-bundler/-/metro-bundler-0.11.0.tgz",
+			"integrity": "sha512-z1b2HtOa1uJVrp5KOx9bvoYRPD8Gn5x+gyFTIGSev7hbDzyAmUoooFUf8yLAfyIVIb4TZGB+tjkn+Skmn41aNQ==",
+			"requires": {
+				"absolute-path": "0.0.0",
+				"async": "2.5.0",
+				"babel-core": "6.26.0",
+				"babel-generator": "6.26.0",
+				"babel-plugin-external-helpers": "6.22.0",
+				"babel-preset-es2015-node": "6.1.1",
+				"babel-preset-fbjs": "2.1.4",
+				"babel-preset-react-native": "2.1.0",
+				"babel-register": "6.26.0",
+				"babylon": "6.18.0",
+				"chalk": "1.1.3",
+				"concat-stream": "1.6.0",
+				"core-js": "2.5.1",
+				"debug": "2.6.8",
+				"denodeify": "1.2.1",
+				"fbjs": "0.8.12",
+				"graceful-fs": "4.1.11",
+				"image-size": "0.6.1",
+				"jest-docblock": "20.1.0-chi.1",
+				"jest-haste-map": "20.1.0-chi.1",
+				"json-stable-stringify": "1.0.1",
+				"json5": "0.4.0",
+				"left-pad": "1.1.3",
+				"lodash": "4.17.4",
+				"merge-stream": "1.0.1",
+				"mime-types": "2.1.11",
+				"mkdirp": "0.5.1",
+				"request": "2.81.0",
+				"rimraf": "2.6.1",
+				"source-map": "0.5.7",
+				"temp": "0.8.3",
+				"throat": "4.1.0",
+				"uglify-js": "2.7.5",
+				"write-file-atomic": "1.3.4",
+				"xpipe": "1.0.5"
+			},
+			"dependencies": {
+				"babel-preset-react-native": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-2.1.0.tgz",
+					"integrity": "sha1-kBPr2C2hyIECv1iIEP9Z4gnKK4o=",
+					"requires": {
+						"babel-plugin-check-es2015-constants": "6.22.0",
+						"babel-plugin-react-transform": "2.0.2",
+						"babel-plugin-syntax-async-functions": "6.13.0",
+						"babel-plugin-syntax-class-properties": "6.13.0",
+						"babel-plugin-syntax-flow": "6.18.0",
+						"babel-plugin-syntax-jsx": "6.18.0",
+						"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+						"babel-plugin-transform-class-properties": "6.24.1",
+						"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+						"babel-plugin-transform-es2015-block-scoping": "6.26.0",
+						"babel-plugin-transform-es2015-classes": "6.24.1",
+						"babel-plugin-transform-es2015-computed-properties": "6.24.1",
+						"babel-plugin-transform-es2015-destructuring": "6.23.0",
+						"babel-plugin-transform-es2015-for-of": "6.23.0",
+						"babel-plugin-transform-es2015-function-name": "6.24.1",
+						"babel-plugin-transform-es2015-literals": "6.22.0",
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+						"babel-plugin-transform-es2015-parameters": "6.24.1",
+						"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+						"babel-plugin-transform-es2015-spread": "6.22.0",
+						"babel-plugin-transform-es2015-template-literals": "6.22.0",
+						"babel-plugin-transform-flow-strip-types": "6.22.0",
+						"babel-plugin-transform-object-assign": "6.22.0",
+						"babel-plugin-transform-object-rest-spread": "6.26.0",
+						"babel-plugin-transform-react-display-name": "6.25.0",
+						"babel-plugin-transform-react-jsx": "6.24.1",
+						"babel-plugin-transform-react-jsx-source": "6.22.0",
+						"babel-plugin-transform-regenerator": "6.26.0",
+						"react-transform-hmr": "1.0.4"
+					}
+				},
+				"core-js": {
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+				},
+				"fbjs": {
+					"version": "0.8.12",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+					"integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+					"requires": {
+						"core-js": "1.2.7",
+						"isomorphic-fetch": "2.2.1",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1",
+						"promise": "7.3.1",
+						"setimmediate": "1.0.5",
+						"ua-parser-js": "0.7.14"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "1.2.7",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+							"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+						}
+					}
+				},
+				"jest-docblock": {
+					"version": "20.1.0-chi.1",
+					"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.1.0-chi.1.tgz",
+					"integrity": "sha512-zX64LtNgTgphO06akqDxKQhVET3uwjZTRalqG2jJoWyEdSUYGp8yjjqicJ7rRu5ZbwnuaB8yqqP9Exu59oDNaA=="
+				},
+				"jest-haste-map": {
+					"version": "20.1.0-chi.1",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.1.0-chi.1.tgz",
+					"integrity": "sha512-G5Bjy3NoSBOR4T5FGqu6VlUJk7BnGUfRXkPcU26HTE06j5T0HEnVoScUsP1+XHSSw0XKq84N2LquppHbg3buxg==",
+					"requires": {
+						"fb-watchman": "2.0.0",
+						"graceful-fs": "4.1.11",
+						"jest-docblock": "20.1.0-chi.1",
+						"micromatch": "2.3.11",
+						"sane": "2.0.0",
+						"worker-farm": "1.5.0"
+					}
+				},
+				"sane": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-2.0.0.tgz",
+					"integrity": "sha1-mct58h9KU6adTQzZV8LbBAJLjrI=",
+					"requires": {
+						"anymatch": "1.3.2",
+						"exec-sh": "0.2.1",
+						"fb-watchman": "2.0.0",
+						"fsevents": "1.1.2",
+						"minimatch": "3.0.4",
+						"minimist": "1.2.0",
+						"walker": "1.0.7",
+						"watch": "0.10.0"
+					}
+				}
+			}
+		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true,
 			"requires": {
 				"arr-diff": "2.0.0",
 				"array-unique": "0.2.1",
@@ -3525,18 +4574,18 @@
 				"normalize-path": "2.1.1",
 				"object.omit": "2.0.1",
 				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.3"
+				"regex-cache": "0.4.4"
 			}
 		},
 		"mime": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/mime/-/mime-1.3.6.tgz",
-			"integrity": "sha1-WR2E02U6awtKO5343lqoEI5y5eA="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.4.0.tgz",
+			"integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ=="
 		},
 		"mime-db": {
-			"version": "1.29.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-			"integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+			"integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
 		},
 		"mime-types": {
 			"version": "2.1.11",
@@ -3552,6 +4601,11 @@
 					"integrity": "sha1-oxtAcK2uon1zLqMzdApk0OyaZlk="
 				}
 			}
+		},
+		"mimic-fn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -3589,11 +4643,6 @@
 				}
 			}
 		},
-		"moment": {
-			"version": "2.18.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-			"integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
-		},
 		"morgan": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
@@ -3626,17 +4675,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
-		"multimatch": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
-			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
-			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
-			}
-		},
 		"multiparty": {
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
@@ -3644,6 +4682,29 @@
 			"requires": {
 				"readable-stream": "1.1.14",
 				"stream-counter": "0.2.0"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
 			}
 		},
 		"multipipe": {
@@ -3655,9 +4716,15 @@
 			}
 		},
 		"mute-stream": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
-			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+		},
+		"nan": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+			"integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+			"optional": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -3671,9 +4738,9 @@
 			"integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
 		},
 		"node-fetch": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-			"integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
+			"version": "1.7.3",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+			"integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
 			"requires": {
 				"encoding": "0.1.12",
 				"is-stream": "1.1.0"
@@ -3692,7 +4759,7 @@
 			"requires": {
 				"growly": "1.3.0",
 				"semver": "5.4.1",
-				"shellwords": "0.1.0",
+				"shellwords": "0.1.1",
 				"which": "1.3.0"
 			}
 		},
@@ -3711,9 +4778,8 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-			"dev": true,
 			"requires": {
-				"remove-trailing-separator": "1.0.2"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"npmlog": {
@@ -3751,7 +4817,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true,
 			"requires": {
 				"for-own": "0.1.5",
 				"is-extendable": "0.1.1"
@@ -3779,9 +4844,12 @@
 			}
 		},
 		"onetime": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+			"integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+			"requires": {
+				"mimic-fn": "1.1.0"
+			}
 		},
 		"opn": {
 			"version": "3.0.3",
@@ -3844,6 +4912,15 @@
 				"lcid": "1.0.0"
 			}
 		},
+		"os-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+			"integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+			"requires": {
+				"macos-release": "1.1.0",
+				"win-release": "1.1.1"
+			}
+		},
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3868,7 +4945,6 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true,
 			"requires": {
 				"glob-base": "0.3.0",
 				"is-dotfile": "1.0.3",
@@ -3930,9 +5006,9 @@
 			"integrity": "sha1-68ikqGGf8LioGsFRPDQ0/0af23Q="
 		},
 		"pegjs": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.9.0.tgz",
-			"integrity": "sha1-9q76LjzlYWkgjlIXnf5B+JFBo2k="
+			"version": "0.10.0",
+			"resolved": "https://registry.npmjs.org/pegjs/-/pegjs-0.10.0.tgz",
+			"integrity": "sha1-z4uvrm7d/0tafvsYUmnqr0YQ3b0="
 		},
 		"performance-now": {
 			"version": "0.2.0",
@@ -3984,28 +5060,12 @@
 		"preserve": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-			"dev": true
+			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"pretty-format": {
-			"version": "19.0.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-19.0.0.tgz",
-			"integrity": "sha1-VlMNMqy5ij+khRxOK503tCBoTIQ=",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "3.2.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-					"dev": true,
-					"requires": {
-						"color-convert": "1.9.0"
-					}
-				}
-			}
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-4.3.1.tgz",
+			"integrity": "sha1-UwvlxCs8BbNkFKeipDN6qArNDo0="
 		},
 		"private": {
 			"version": "0.1.7",
@@ -4028,6 +5088,15 @@
 			"integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
 			"requires": {
 				"asap": "2.0.6"
+			}
+		},
+		"prop-types": {
+			"version": "15.5.10",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+			"integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+			"requires": {
+				"fbjs": "0.8.15",
+				"loose-envify": "1.3.1"
 			}
 		},
 		"prr": {
@@ -4059,7 +5128,6 @@
 			"version": "1.1.7",
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-			"dev": true,
 			"requires": {
 				"is-number": "3.0.0",
 				"kind-of": "4.0.0"
@@ -4069,7 +5137,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-					"dev": true,
 					"requires": {
 						"kind-of": "3.2.2"
 					},
@@ -4078,7 +5145,6 @@
 							"version": "3.2.2",
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-							"dev": true,
 							"requires": {
 								"is-buffer": "1.1.5"
 							}
@@ -4089,7 +5155,6 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-					"dev": true,
 					"requires": {
 						"is-buffer": "1.1.5"
 					}
@@ -4124,13 +5189,15 @@
 			}
 		},
 		"react": {
-			"version": "15.4.2",
-			"resolved": "https://registry.npmjs.org/react/-/react-15.4.2.tgz",
-			"integrity": "sha1-QfeZGyYYU5K6m66WyIiefgGDl+8=",
+			"version": "16.0.0-alpha.12",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.0.0-alpha.12.tgz",
+			"integrity": "sha1-jFlIUoFIXfMZtvd2gtjdBiHAgZQ=",
 			"requires": {
-				"fbjs": "0.8.14",
+				"create-react-class": "15.6.0",
+				"fbjs": "0.8.15",
 				"loose-envify": "1.3.1",
-				"object-assign": "4.1.1"
+				"object-assign": "4.1.1",
+				"prop-types": "15.5.10"
 			}
 		},
 		"react-clone-referenced-element": {
@@ -4139,68 +5206,101 @@
 			"integrity": "sha1-K7qMaUBMXkqUQ5hgC8xMlB+GBoI="
 		},
 		"react-deep-force-update": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz",
-			"integrity": "sha1-+RG1vh0qb+OHUH3W6adnqikktMc="
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz",
+			"integrity": "sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw="
+		},
+		"react-devtools-core": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.5.0.tgz",
+			"integrity": "sha512-sLlDHiY+DoOnzEXdLwSGxob3MtiIwM54s6FBbVAc/iOorNd8Nv1aVUTsZpTnJXDYa8p5VPNdCR4ATQ0HcIBh+Q==",
+			"requires": {
+				"shell-quote": "1.6.1",
+				"ws": "2.3.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+					"integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+				},
+				"ws": {
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+					"integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+					"requires": {
+						"safe-buffer": "5.0.1",
+						"ultron": "1.1.0"
+					}
+				}
+			}
 		},
 		"react-native": {
-			"version": "0.42.0",
-			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.42.0.tgz",
-			"integrity": "sha1-WbUBYDpjIyWY//ZTo2MHomAQQC4=",
+			"version": "0.48.2",
+			"resolved": "https://registry.npmjs.org/react-native/-/react-native-0.48.2.tgz",
+			"integrity": "sha1-mQfVpzZAreOSBwHnCW/BCbqcxuQ=",
 			"requires": {
 				"absolute-path": "0.0.0",
 				"art": "0.10.1",
 				"async": "2.5.0",
-				"babel-core": "6.25.0",
-				"babel-generator": "6.25.0",
+				"babel-core": "6.26.0",
+				"babel-generator": "6.26.0",
 				"babel-plugin-external-helpers": "6.22.0",
 				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
+				"babel-plugin-transform-async-to-generator": "6.16.0",
+				"babel-plugin-transform-class-properties": "6.24.1",
 				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-plugin-transform-object-rest-spread": "6.23.0",
-				"babel-polyfill": "6.23.0",
+				"babel-plugin-transform-object-rest-spread": "6.26.0",
+				"babel-polyfill": "6.26.0",
 				"babel-preset-es2015-node": "6.1.1",
 				"babel-preset-fbjs": "2.1.4",
-				"babel-preset-react-native": "1.9.2",
-				"babel-register": "6.24.1",
-				"babel-runtime": "6.25.0",
-				"babel-traverse": "6.25.0",
-				"babel-types": "6.25.0",
-				"babylon": "6.17.4",
+				"babel-preset-react-native": "2.1.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
 				"base64-js": "1.2.1",
 				"bser": "1.0.3",
 				"chalk": "1.1.3",
 				"commander": "2.11.0",
+				"concat-stream": "1.6.0",
 				"connect": "2.30.2",
-				"core-js": "2.4.1",
+				"core-js": "2.5.1",
+				"create-react-class": "15.6.0",
 				"debug": "2.6.8",
 				"denodeify": "1.2.1",
+				"envinfo": "3.4.1",
+				"errno": "0.1.4",
 				"event-target-shim": "1.1.1",
-				"fbjs": "0.8.14",
+				"fbjs": "0.8.12",
 				"fbjs-scripts": "0.7.1",
-				"fs-extra": "0.26.7",
-				"glob": "5.0.15",
+				"form-data": "2.3.1",
+				"fs-extra": "1.0.0",
+				"glob": "7.1.2",
 				"graceful-fs": "4.1.11",
-				"image-size": "0.3.5",
-				"immutable": "3.7.6",
-				"imurmurhash": "0.1.4",
-				"inquirer": "0.12.0",
-				"jest-haste-map": "18.0.0",
-				"joi": "6.10.1",
+				"inquirer": "3.2.3",
+				"jest-haste-map": "20.1.0-delta.4",
 				"json-stable-stringify": "1.0.1",
 				"json5": "0.4.0",
 				"left-pad": "1.1.3",
 				"lodash": "4.17.4",
-				"mime": "1.3.6",
+				"merge-stream": "1.0.1",
+				"metro-bundler": "0.11.0",
+				"mime": "1.4.0",
 				"mime-types": "2.1.11",
 				"minimist": "1.2.0",
 				"mkdirp": "0.5.1",
-				"node-fetch": "1.7.1",
+				"node-fetch": "1.7.3",
 				"npmlog": "2.0.4",
 				"opn": "3.0.3",
 				"optimist": "0.6.1",
 				"plist": "1.2.0",
+				"pretty-format": "4.3.1",
 				"promise": "7.3.1",
+				"prop-types": "15.5.10",
 				"react-clone-referenced-element": "1.0.1",
+				"react-devtools-core": "2.5.0",
 				"react-timer-mixin": "0.13.3",
 				"react-transform-hmr": "1.0.4",
 				"rebound": "0.0.13",
@@ -4210,25 +5310,25 @@
 				"sane": "1.4.1",
 				"semver": "5.4.1",
 				"shell-quote": "1.6.1",
-				"source-map": "0.5.6",
+				"source-map": "0.5.7",
 				"stacktrace-parser": "0.1.4",
 				"temp": "0.8.3",
-				"throat": "3.2.0",
-				"uglify-js": "2.8.29",
+				"throat": "4.1.0",
 				"whatwg-fetch": "1.1.1",
 				"wordwrap": "1.0.0",
-				"worker-farm": "1.4.1",
 				"write-file-atomic": "1.3.4",
 				"ws": "1.1.4",
-				"xcode": "0.8.9",
+				"xcode": "0.9.3",
 				"xmldoc": "0.4.0",
+				"xpipe": "1.0.5",
+				"xtend": "4.0.1",
 				"yargs": "6.6.0"
 			},
 			"dependencies": {
 				"babel-preset-react-native": {
-					"version": "1.9.2",
-					"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-1.9.2.tgz",
-					"integrity": "sha1-sird0uNV/zs5Zxt5voB+Ut+hRfI=",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-2.1.0.tgz",
+					"integrity": "sha1-kBPr2C2hyIECv1iIEP9Z4gnKK4o=",
 					"requires": {
 						"babel-plugin-check-es2015-constants": "6.22.0",
 						"babel-plugin-react-transform": "2.0.2",
@@ -4239,32 +5339,53 @@
 						"babel-plugin-syntax-trailing-function-commas": "6.22.0",
 						"babel-plugin-transform-class-properties": "6.24.1",
 						"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-						"babel-plugin-transform-es2015-block-scoping": "6.24.1",
+						"babel-plugin-transform-es2015-block-scoping": "6.26.0",
 						"babel-plugin-transform-es2015-classes": "6.24.1",
 						"babel-plugin-transform-es2015-computed-properties": "6.24.1",
 						"babel-plugin-transform-es2015-destructuring": "6.23.0",
 						"babel-plugin-transform-es2015-for-of": "6.23.0",
 						"babel-plugin-transform-es2015-function-name": "6.24.1",
 						"babel-plugin-transform-es2015-literals": "6.22.0",
-						"babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+						"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
 						"babel-plugin-transform-es2015-parameters": "6.24.1",
 						"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
 						"babel-plugin-transform-es2015-spread": "6.22.0",
 						"babel-plugin-transform-es2015-template-literals": "6.22.0",
 						"babel-plugin-transform-flow-strip-types": "6.22.0",
 						"babel-plugin-transform-object-assign": "6.22.0",
-						"babel-plugin-transform-object-rest-spread": "6.23.0",
+						"babel-plugin-transform-object-rest-spread": "6.26.0",
 						"babel-plugin-transform-react-display-name": "6.25.0",
 						"babel-plugin-transform-react-jsx": "6.24.1",
 						"babel-plugin-transform-react-jsx-source": "6.22.0",
-						"babel-plugin-transform-regenerator": "6.24.1",
+						"babel-plugin-transform-regenerator": "6.26.0",
 						"react-transform-hmr": "1.0.4"
 					}
 				},
 				"core-js": {
-					"version": "2.4.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-					"integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+					"version": "2.5.1",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+					"integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+				},
+				"fbjs": {
+					"version": "0.8.12",
+					"resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+					"integrity": "sha1-ELXZL3bUVXX9Y6IX1OoCvqL47QQ=",
+					"requires": {
+						"core-js": "1.2.7",
+						"isomorphic-fetch": "2.2.1",
+						"loose-envify": "1.3.1",
+						"object-assign": "4.1.1",
+						"promise": "7.3.1",
+						"setimmediate": "1.0.5",
+						"ua-parser-js": "0.7.14"
+					},
+					"dependencies": {
+						"core-js": {
+							"version": "1.2.7",
+							"resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+							"integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+						}
+					}
 				},
 				"whatwg-fetch": {
 					"version": "1.1.1",
@@ -4282,7 +5403,7 @@
 			"integrity": "sha1-nb/Z2SdSjDqp9ETkVYw3gwq4wmo=",
 			"requires": {
 				"lodash": "4.17.4",
-				"react-deep-force-update": "1.0.1"
+				"react-deep-force-update": "1.1.1"
 			}
 		},
 		"react-test-renderer": {
@@ -4291,7 +5412,7 @@
 			"integrity": "sha1-J+Hf9dJtDoMPmWFMSHYivIMUFvM=",
 			"dev": true,
 			"requires": {
-				"fbjs": "0.8.14",
+				"fbjs": "0.8.15",
 				"object-assign": "4.1.1"
 			}
 		},
@@ -4329,24 +5450,17 @@
 			}
 		},
 		"readable-stream": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-			"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
 			"requires": {
 				"core-util-is": "1.0.2",
 				"inherits": "2.0.3",
-				"isarray": "0.0.1",
-				"string_decoder": "0.10.31"
-			}
-		},
-		"readline2": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
-			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"mute-stream": "0.0.5"
+				"isarray": "1.0.0",
+				"process-nextick-args": "1.0.7",
+				"safe-buffer": "5.1.1",
+				"string_decoder": "1.0.3",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"rebound": {
@@ -4365,23 +5479,21 @@
 			"integrity": "sha1-0z65XQ0gAaS+OWWXB8UbDLcc4Ck="
 		},
 		"regenerator-transform": {
-			"version": "0.9.11",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-			"integrity": "sha1-On0GdSDLe3F2dp61/4aGkb7+EoM=",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
+			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "6.25.0",
-				"babel-types": "6.25.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
 				"private": "0.1.7"
 			}
 		},
 		"regex-cache": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-			"dev": true,
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
-				"is-equal-shallow": "0.1.3",
-				"is-primitive": "2.0.0"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regexpu-core": {
@@ -4415,16 +5527,14 @@
 			}
 		},
 		"remove-trailing-separator": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
-			"integrity": "sha1-abBi2XhyetFNxrVrpKt3L9jXBRE=",
-			"dev": true
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
 		},
 		"repeat-element": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-			"dev": true
+			"integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
 		},
 		"repeat-string": {
 			"version": "1.6.1",
@@ -4473,6 +5583,26 @@
 				"uuid": "3.1.0"
 			},
 			"dependencies": {
+				"form-data": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+					"integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+					"requires": {
+						"asynckit": "0.4.0",
+						"combined-stream": "1.0.5",
+						"mime-types": "2.1.17"
+					},
+					"dependencies": {
+						"mime-types": {
+							"version": "2.1.17",
+							"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+							"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+							"requires": {
+								"mime-db": "1.30.0"
+							}
+						}
+					}
+				},
 				"qs": {
 					"version": "6.4.0",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
@@ -4516,12 +5646,12 @@
 			}
 		},
 		"restore-cursor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+			"integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
 			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
+				"onetime": "2.0.1",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"right-align": {
@@ -4538,21 +5668,6 @@
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
 			"requires": {
 				"glob": "7.1.2"
-			},
-			"dependencies": {
-				"glob": {
-					"version": "7.1.2",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				}
 			}
 		},
 		"rndm": {
@@ -4561,17 +5676,25 @@
 			"integrity": "sha1-8z/pz7Urv9UgqhgyO8ZdsRCht2w="
 		},
 		"run-async": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+			"integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
 			"requires": {
-				"once": "1.4.0"
+				"is-promise": "2.1.0"
 			}
 		},
 		"rx-lite": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
-			"integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI="
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+			"integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ="
+		},
+		"rx-lite-aggregates": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+			"integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+			"requires": {
+				"rx-lite": "4.0.8"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.1",
@@ -4583,12 +5706,30 @@
 			"resolved": "https://registry.npmjs.org/sane/-/sane-1.4.1.tgz",
 			"integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
 			"requires": {
-				"exec-sh": "0.2.0",
+				"exec-sh": "0.2.1",
 				"fb-watchman": "1.9.2",
 				"minimatch": "3.0.4",
 				"minimist": "1.2.0",
 				"walker": "1.0.7",
 				"watch": "0.10.0"
+			},
+			"dependencies": {
+				"bser": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
+					"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
+					"requires": {
+						"node-int64": "0.4.0"
+					}
+				},
+				"fb-watchman": {
+					"version": "1.9.2",
+					"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
+					"integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
+					"requires": {
+						"bser": "1.0.2"
+					}
+				}
 			}
 		},
 		"sax": {
@@ -4729,19 +5870,46 @@
 			}
 		},
 		"shellwords": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.0.tgz",
-			"integrity": "sha1-Zq/Ue2oSky2Qccv9mKUueFzQuhQ=",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
+			"integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
 			"dev": true
 		},
+		"signal-exit": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+		},
 		"simple-plist": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.1.4.tgz",
-			"integrity": "sha1-EOtRtH4zxVbrjsRtXuZNZOcX210=",
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-0.2.1.tgz",
+			"integrity": "sha1-cXZts1IyaSjPOoByQrp2IyJjZyM=",
 			"requires": {
-				"bplist-creator": "0.0.4",
-				"bplist-parser": "0.0.6",
-				"plist": "1.2.0"
+				"bplist-creator": "0.0.7",
+				"bplist-parser": "0.1.1",
+				"plist": "2.0.1"
+			},
+			"dependencies": {
+				"base64-js": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.1.2.tgz",
+					"integrity": "sha1-1kAMrBxMZgl22Q0HoENR2JOV9eg="
+				},
+				"plist": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/plist/-/plist-2.0.1.tgz",
+					"integrity": "sha1-CjLKlIGxw2TpLhjcVch23p0B2os=",
+					"requires": {
+						"base64-js": "1.1.2",
+						"xmlbuilder": "8.2.2",
+						"xmldom": "0.1.27"
+					}
+				},
+				"xmlbuilder": {
+					"version": "8.2.2",
+					"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+					"integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M="
+				}
 			}
 		},
 		"slash": {
@@ -4763,16 +5931,16 @@
 			}
 		},
 		"source-map": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-			"integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-support": {
-			"version": "0.4.15",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-			"integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
+			"integrity": "sha512-30c1Ch8FSjV0FwC253iftbbj0dU/OXoSg1LAEGZJUlGgjTNj6cu+DVqJWWIZJY5RXLWV4eFtR+4ouo0VIOYOTg==",
 			"requires": {
-				"source-map": "0.5.6"
+				"source-map": "0.5.7"
 			}
 		},
 		"sparkles": {
@@ -4837,9 +6005,9 @@
 			"integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
 		},
 		"stream-buffers": {
-			"version": "0.2.6",
-			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.6.tgz",
-			"integrity": "sha1-GBwI1bs2kARfaUAbmuanoM8zE/w="
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+			"integrity": "sha1-kdX1Ew0c75bc+n9yaUUYh0HQnuQ="
 		},
 		"stream-counter": {
 			"version": "0.2.0",
@@ -4847,12 +6015,30 @@
 			"integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
 			"requires": {
 				"readable-stream": "1.1.14"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"readable-stream": {
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+					"requires": {
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "0.0.1",
+						"string_decoder": "0.10.31"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				}
 			}
-		},
-		"string_decoder": {
-			"version": "0.10.31",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-			"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
 		},
 		"string-length": {
 			"version": "1.0.1",
@@ -4864,13 +6050,35 @@
 			}
 		},
 		"string-width": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"requires": {
+						"ansi-regex": "3.0.0"
+					}
+				}
+			}
+		},
+		"string_decoder": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"requires": {
+				"safe-buffer": "5.1.1"
 			}
 		},
 		"stringstream": {
@@ -4935,9 +6143,9 @@
 			}
 		},
 		"throat": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-			"integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+			"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
 		},
 		"through": {
 			"version": "2.3.8",
@@ -4951,41 +6159,20 @@
 			"requires": {
 				"readable-stream": "2.3.3",
 				"xtend": "4.0.1"
-			},
-			"dependencies": {
-				"isarray": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-				},
-				"readable-stream": {
-					"version": "2.3.3",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"safe-buffer": "5.1.1",
-						"string_decoder": "1.0.3",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"string_decoder": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-					"requires": {
-						"safe-buffer": "5.1.1"
-					}
-				}
 			}
 		},
 		"time-stamp": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
 			"integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
+		},
+		"tmp": {
+			"version": "0.0.31",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+			"integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+			"requires": {
+				"os-tmpdir": "1.0.2"
+			}
 		},
 		"tmpl": {
 			"version": "1.0.4",
@@ -4996,14 +6183,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
-		},
-		"topo": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-			"integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-			"requires": {
-				"hoek": "2.16.3"
-			}
 		},
 		"tough-cookie": {
 			"version": "2.3.2",
@@ -5058,18 +6237,23 @@
 			"integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
 			"requires": {
 				"media-typer": "0.3.0",
-				"mime-types": "2.1.16"
+				"mime-types": "2.1.17"
 			},
 			"dependencies": {
 				"mime-types": {
-					"version": "2.1.16",
-					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-					"integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+					"version": "2.1.17",
+					"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+					"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 					"requires": {
-						"mime-db": "1.29.0"
+						"mime-db": "1.30.0"
 					}
 				}
 			}
+		},
+		"typedarray": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"ua-parser-js": {
 			"version": "0.7.14",
@@ -5077,15 +6261,21 @@
 			"integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
 		},
 		"uglify-js": {
-			"version": "2.8.29",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+			"version": "2.7.5",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+			"integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
 			"requires": {
-				"source-map": "0.5.6",
+				"async": "0.2.10",
+				"source-map": "0.5.7",
 				"uglify-to-browserify": "1.0.2",
 				"yargs": "3.10.0"
 			},
 			"dependencies": {
+				"async": {
+					"version": "0.2.10",
+					"resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+					"integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+				},
 				"yargs": {
 					"version": "3.10.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
@@ -5102,8 +6292,7 @@
 		"uglify-to-browserify": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-			"optional": true
+			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
 		},
 		"uid-safe": {
 			"version": "2.1.4",
@@ -5114,9 +6303,9 @@
 			}
 		},
 		"ultron": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-			"integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+			"integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -5198,9 +6387,9 @@
 			"integrity": "sha1-d3mLLaD5kQ1ZXxrOWwwiWFIfIdw="
 		},
 		"webidl-conversions": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
-			"integrity": "sha1-gBWherg+fhsxFjhIas6B2mziBqA=",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+			"integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
 			"dev": true
 		},
 		"whatwg-encoding": {
@@ -5256,6 +6445,14 @@
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
 			"integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
 		},
+		"win-release": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+			"integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+			"requires": {
+				"semver": "5.4.1"
+			}
+		},
 		"window-size": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -5267,9 +6464,9 @@
 			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"worker-farm": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.4.1.tgz",
-			"integrity": "sha512-tgFAtgOYLPutkAyzgpS6VJFL5HY+0ui1Tvua+fITgz8ByaJTMFGtazR6xxQfwfiAcbwE+2fLG/K49wc2TfwCNw==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.0.tgz",
+			"integrity": "sha512-DHRiUggxtbruaTwnLDm2/BRDKZIoOYvrgYUj5Bam4fU6Gtvc0FaEyoswFPBjMXAweGW2H4BDNIpy//1yXXuaqQ==",
 			"requires": {
 				"errno": "0.1.4",
 				"xtend": "4.0.1"
@@ -5282,6 +6479,26 @@
 			"requires": {
 				"string-width": "1.0.2",
 				"strip-ansi": "3.0.1"
+			},
+			"dependencies": {
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
+					}
+				}
 			}
 		},
 		"wrappy": {
@@ -5306,22 +6523,29 @@
 			"requires": {
 				"options": "0.0.6",
 				"ultron": "1.0.2"
+			},
+			"dependencies": {
+				"ultron": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+					"integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+				}
 			}
 		},
 		"xcode": {
-			"version": "0.8.9",
-			"resolved": "https://registry.npmjs.org/xcode/-/xcode-0.8.9.tgz",
-			"integrity": "sha1-7Gdl9w6dzMzJ9umlubTn6BS0zzU=",
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/xcode/-/xcode-0.9.3.tgz",
+			"integrity": "sha1-kQqJwWrubMC0LKgFptC0z4chHPM=",
 			"requires": {
-				"node-uuid": "1.4.7",
-				"pegjs": "0.9.0",
-				"simple-plist": "0.1.4"
+				"pegjs": "0.10.0",
+				"simple-plist": "0.2.1",
+				"uuid": "3.0.1"
 			},
 			"dependencies": {
-				"node-uuid": {
-					"version": "1.4.7",
-					"resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-					"integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
+				"uuid": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+					"integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
 				}
 			}
 		},
@@ -5358,6 +6582,11 @@
 			"version": "0.1.27",
 			"resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
 			"integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+		},
+		"xpipe": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/xpipe/-/xpipe-1.0.5.tgz",
+			"integrity": "sha1-jdi/Rfw/f1Xw4FS4ePQ6YmFNr98="
 		},
 		"xtend": {
 			"version": "4.0.1",
@@ -5407,6 +6636,24 @@
 						"string-width": "1.0.2",
 						"strip-ansi": "3.0.1",
 						"wrap-ansi": "2.1.0"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+					"requires": {
+						"number-is-nan": "1.0.1"
+					}
+				},
+				"string-width": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+					"requires": {
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				}
 			}

--- a/examples/testbed_simple/package-lock.json
+++ b/examples/testbed_simple/package-lock.json
@@ -5407,9 +5407,9 @@
 			}
 		},
 		"react-test-renderer": {
-			"version": "15.4.2",
-			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.4.2.tgz",
-			"integrity": "sha1-J+Hf9dJtDoMPmWFMSHYivIMUFvM=",
+			"version": "16.0.0-alpha.12",
+			"resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.0.0-alpha.12.tgz",
+			"integrity": "sha1-nkzF2M6L/KcneDQN4+FFS51sDMU=",
 			"dev": true,
 			"requires": {
 				"fbjs": "0.8.15",

--- a/examples/testbed_simple/package.json
+++ b/examples/testbed_simple/package.json
@@ -7,8 +7,8 @@
 		"test": "jest"
 	},
 	"dependencies": {
-		"react": "~15.4.1",
-		"react-native": "0.42.0",
+		"react": "16.0.0-alpha.12",
+		"react-native": "0.48.2",
 		"react-native-branch": "file:../.."
 	},
 	"devDependencies": {

--- a/examples/testbed_simple/package.json
+++ b/examples/testbed_simple/package.json
@@ -15,7 +15,7 @@
 		"babel-jest": "19.0.0",
 		"babel-preset-react-native": "1.9.1",
 		"jest": "19.0.2",
-		"react-test-renderer": "~15.4.1"
+		"react-test-renderer": "16.0.0-alpha.12"
 	},
 	"jest": {
 		"preset": "react-native"

--- a/examples/testbed_simple/yarn.lock
+++ b/examples/testbed_simple/yarn.lock
@@ -1593,18 +1593,6 @@ fbjs@0.8.12:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.4:
-  version "0.8.14"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
 fbjs@^0.8.9:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
@@ -3448,11 +3436,11 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-test-renderer@~15.4.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
+react-test-renderer@16.0.0-alpha.12:
+  version "16.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0-alpha.12.tgz#9e4cc5d8ce8bfca72778340de3e1454b9d6c0cc5"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     object-assign "^4.1.0"
 
 react-timer-mixin@^0.13.2:

--- a/examples/testbed_simple/yarn.lock
+++ b/examples/testbed_simple/yarn.lock
@@ -6,6 +6,10 @@ abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
 
+abbrev@1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
+
 absolute-path@^0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/absolute-path/-/absolute-path-0.0.0.tgz#a78762fbdadfb5297be99b15d35a785b2f095bf7"
@@ -53,19 +57,27 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
+ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
+
+ansi-escapes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
 ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
+ansi-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
+
 ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0:
+ansi-styles@^3.0.0, ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -87,6 +99,10 @@ append-transform@^0.4.0:
   resolved "https://registry.yarnpkg.com/append-transform/-/append-transform-0.4.0.tgz#d76ebf8ca94d276e247a36bad44a4b74ab611991"
   dependencies:
     default-require-extensions "^1.0.0"
+
+aproba@^1.0.3:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
 
 are-we-there-yet@~1.1.2:
   version "1.1.4"
@@ -131,13 +147,7 @@ array-reduce@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
 
-array-union@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
-  dependencies:
-    array-uniq "^1.0.1"
-
-array-uniq@^1.0.1, array-uniq@^1.0.2:
+array-uniq@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
@@ -145,7 +155,7 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-arrify@^1.0.0, arrify@^1.0.1:
+arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
@@ -173,11 +183,15 @@ async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.0.1, async@^2.1.4:
+async@^2.1.4, async@^2.4.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
     lodash "^4.14.0"
+
+async@~0.2.6:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/async/-/async-0.2.10.tgz#b6bbe0b0674b9d719708ca38de8c237cb526c3d1"
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -199,7 +213,7 @@ babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.21.0, babel-core@^6.24.1, babel-core@^6.7.2:
+babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.7.2:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -223,7 +237,7 @@ babel-core@^6.0.0, babel-core@^6.21.0, babel-core@^6.24.1, babel-core@^6.7.2:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-generator@^6.18.0, babel-generator@^6.21.0, babel-generator@^6.25.0:
+babel-generator@^6.18.0, babel-generator@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.25.0.tgz#33a1af70d5f2890aeb465a4a7793c1df6a9ea9fc"
   dependencies:
@@ -234,6 +248,19 @@ babel-generator@^6.18.0, babel-generator@^6.21.0, babel-generator@^6.25.0:
     jsesc "^1.3.0"
     lodash "^4.2.0"
     source-map "^0.5.0"
+    trim-right "^1.0.1"
+
+babel-generator@^6.24.1:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.0.tgz#ac1ae20070b79f6e3ca1d3269613053774f20dc5"
+  dependencies:
+    babel-messages "^6.23.0"
+    babel-runtime "^6.26.0"
+    babel-types "^6.26.0"
+    detect-indent "^4.0.0"
+    jsesc "^1.3.0"
+    lodash "^4.17.4"
+    source-map "^0.5.6"
     trim-right "^1.0.1"
 
 babel-helper-builder-react-jsx@^6.24.1:
@@ -301,6 +328,16 @@ babel-helper-regex@^6.24.1:
     babel-types "^6.24.1"
     lodash "^4.2.0"
 
+babel-helper-remap-async-to-generator@^6.16.0:
+  version "6.24.1"
+  resolved "https://registry.yarnpkg.com/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz#bf6dbfe43938d17369a213ca8a8bf74b6a90ab1a"
@@ -363,7 +400,7 @@ babel-plugin-react-transform@2.0.2:
   dependencies:
     lodash "^4.6.1"
 
-babel-plugin-syntax-async-functions@^6.5.0:
+babel-plugin-syntax-async-functions@^6.5.0, babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
@@ -387,7 +424,15 @@ babel-plugin-syntax-trailing-function-commas@^6.20.0, babel-plugin-syntax-traili
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
 
-babel-plugin-transform-class-properties@^6.5.0, babel-plugin-transform-class-properties@^6.6.0, babel-plugin-transform-class-properties@^6.8.0:
+babel-plugin-transform-async-to-generator@6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.16.0.tgz#19ec36cb1486b59f9f468adfa42ce13908ca2999"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.16.0"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.0.0"
+
+babel-plugin-transform-class-properties@^6.18.0, babel-plugin-transform-class-properties@^6.5.0, babel-plugin-transform-class-properties@^6.6.0, babel-plugin-transform-class-properties@^6.8.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
   dependencies:
@@ -644,7 +689,7 @@ babel-preset-fbjs@^1.0.0:
     babel-plugin-transform-object-rest-spread "^6.6.5"
     object-assign "^4.0.1"
 
-babel-preset-fbjs@^2.1.0:
+babel-preset-fbjs@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz#22f358e6654073acf61e47a052a777d7bccf03af"
   dependencies:
@@ -717,9 +762,9 @@ babel-preset-react-native@1.9.1:
     babel-plugin-transform-regenerator "^6.5.0"
     react-transform-hmr "^1.0.4"
 
-babel-preset-react-native@^1.9.1:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-native/-/babel-preset-react-native-1.9.2.tgz#b22addd2e355ff3b39671b79be807e52dfa145f2"
+babel-preset-react-native@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-react-native/-/babel-preset-react-native-2.1.0.tgz#9013ebd82da1c88102bf588810ff59e209ca2b8a"
   dependencies:
     babel-plugin-check-es2015-constants "^6.5.0"
     babel-plugin-react-transform "2.0.2"
@@ -751,7 +796,7 @@ babel-preset-react-native@^1.9.1:
     babel-plugin-transform-regenerator "^6.5.0"
     react-transform-hmr "^1.0.4"
 
-babel-register@^6.18.0, babel-register@^6.24.1:
+babel-register@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
   dependencies:
@@ -763,7 +808,14 @@ babel-register@^6.18.0, babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0:
+babel-runtime@^6.0.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
+babel-runtime@^6.18.0, babel-runtime@^6.22.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
   dependencies:
@@ -780,7 +832,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
     babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.21.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
+babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
@@ -794,7 +846,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.21.0, babel-traverse@^6.24.1, babel-tr
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.21.0, babel-types@^6.24.1, babel-types@^6.25.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -803,7 +855,20 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.21.0, babel-types@^6.24
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.14.1, babylon@^6.17.2, babylon@^6.17.4:
+babel-types@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
+  dependencies:
+    babel-runtime "^6.26.0"
+    esutils "^2.0.2"
+    lodash "^4.17.4"
+    to-fast-properties "^1.0.3"
+
+babylon@^6.17.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+babylon@^6.17.2, babylon@^6.17.4:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -814,6 +879,10 @@ balanced-match@^1.0.0:
 base64-js@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-0.0.8.tgz#1101e9544f4a76b1bc3b26d452ca96d7a35e7978"
+
+base64-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.1.2.tgz#d6400cac1c4c660976d90d07a04351d89395f5e8"
 
 base64-js@^1.1.2:
   version "1.2.1"
@@ -845,6 +914,16 @@ beeper@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/beeper/-/beeper-1.1.1.tgz#e6d5ea8c5dad001304a70b22638447f69cb2f809"
 
+big-integer@^1.6.7:
+  version "1.6.25"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.25.tgz#1de45a9f57542ac20121c682f8d642220a34e823"
+
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  dependencies:
+    inherits "~2.0.0"
+
 body-parser@~1.13.3:
   version "1.13.3"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.13.3.tgz#c08cf330c3358e151016a05746f13f029c97fa97"
@@ -866,15 +945,17 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bplist-creator@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.4.tgz#4ac0496782e127a85c1d2026a4f5eb22a7aff991"
+bplist-creator@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/bplist-creator/-/bplist-creator-0.0.7.tgz#37df1536092824b87c42f957b01344117372ae45"
   dependencies:
-    stream-buffers "~0.2.3"
+    stream-buffers "~2.2.0"
 
-bplist-parser@0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.0.6.tgz#38da3471817df9d44ab3892e27707bbbd75a11b9"
+bplist-parser@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.1.1.tgz#d60d5dcc20cba6dc7e1f299b35d3e1f95dafbae6"
+  dependencies:
+    big-integer "^1.6.7"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -960,15 +1041,23 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
+chalk@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 ci-info@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
 
-cli-cursor@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
-    restore-cursor "^1.0.1"
+    restore-cursor "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -1047,6 +1136,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+concat-stream@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
+  dependencies:
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 connect-timeout@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/connect-timeout/-/connect-timeout-1.6.2.tgz#de9a5ec61e33a12b6edaab7b5f062e98c599b88e"
@@ -1092,6 +1189,10 @@ connect@^2.8.3:
     utils-merge "1.0.0"
     vhost "~3.0.1"
 
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
 content-type-parser@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.1.tgz#c3e56988c53c65127fb46d4032a3a900246fdc94"
@@ -1134,6 +1235,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 crc@3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/crc/-/crc-3.3.0.tgz#fa622e1bc388bf257309082d6b65200ce67090ba"
+
+create-react-class@^15.5.2:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.0.tgz#ab448497c26566e1e29413e883207d57cfe7bed4"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 cross-spawn@^3.0.1:
   version "3.0.1"
@@ -1201,6 +1310,14 @@ decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+deep-equal@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
+
+deep-extend@~0.4.0:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -1210,6 +1327,17 @@ default-require-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/default-require-extensions/-/default-require-extensions-1.0.0.tgz#f37ea15d3e13ffd9b437d33e1a75b5fb97874cb8"
   dependencies:
     strip-bom "^2.0.0"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+defined@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1271,7 +1399,15 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-errno@^0.1.4:
+envinfo@^3.0.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-3.4.1.tgz#8c80e9f2eec2cd4e2adb2c5d0127ce07a2aaa2ae"
+  dependencies:
+    minimist "^1.2.0"
+    os-name "^2.0.1"
+    which "^1.2.14"
+
+"errno@>=0.1.1 <0.2.0-0", errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -1289,6 +1425,24 @@ errorhandler@~1.4.2:
   dependencies:
     accepts "~1.3.0"
     escape-html "~1.0.3"
+
+es-abstract@^1.5.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 escape-html@1.0.2:
   version "1.0.2"
@@ -1343,10 +1497,6 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-
 expand-brackets@^0.1.4:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-0.1.5.tgz#df07284e342a807cd733ac5af72411e581d1177b"
@@ -1377,6 +1527,14 @@ extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+external-editor@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.0.4.tgz#1ed9199da9cbfe2ef2f7a31b2fde8b0d12368972"
+  dependencies:
+    iconv-lite "^0.4.17"
+    jschardet "^1.4.2"
+    tmp "^0.0.31"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -1398,7 +1556,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fb-watchman@^1.8.0, fb-watchman@^1.9.0:
+fb-watchman@^1.8.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-1.9.2.tgz#a24cf47827f82d38fb59a69ad70b76e3b6ae7383"
   dependencies:
@@ -1423,7 +1581,19 @@ fbjs-scripts@^0.7.0:
     semver "^5.1.0"
     through2 "^2.0.0"
 
-fbjs@^0.8.4, fbjs@^0.8.5:
+fbjs@0.8.12:
+  version "0.8.12"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.4:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
   dependencies:
@@ -1435,12 +1605,23 @@ fbjs@^0.8.4, fbjs@^0.8.5:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-figures@^1.3.5:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
+fbjs@^0.8.9:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
   dependencies:
     escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 filename-regex@^2.0.0:
   version "2.0.1"
@@ -1485,6 +1666,12 @@ find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+for-each@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+  dependencies:
+    is-function "~1.0.0"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1495,9 +1682,21 @@ for-own@^0.1.4:
   dependencies:
     for-in "^1.0.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@^2.1.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
 
 form-data@~2.1.1:
   version "2.1.4"
@@ -1511,19 +1710,45 @@ fresh@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.3.0.tgz#651f838e22424e7566de161d8358caa199f83d4f"
 
-fs-extra@^0.26.2:
-  version "0.26.7"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
+fs-extra@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-1.0.0.tgz#cd3ce5f7e7cb6145883fcae3191e9877f8587950"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
     klaw "^1.0.0"
-    path-is-absolute "^1.0.0"
-    rimraf "^2.2.8"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fsevents@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.1.2.tgz#3282b713fb3ad80ede0e9fcf4611b5aa6fc033f4"
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.36"
+
+fstream-ignore@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/fstream-ignore/-/fstream-ignore-1.0.5.tgz#9c31dae34767018fe1d249b24dada67d092da105"
+  dependencies:
+    fstream "^1.0.0"
+    inherits "2"
+    minimatch "^3.0.0"
+
+fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
+  dependencies:
+    graceful-fs "^4.1.2"
+    inherits "~2.0.0"
+    mkdirp ">=0.5 0"
+    rimraf "2"
+
+function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~1.2.5:
   version "1.2.7"
@@ -1534,6 +1759,19 @@ gauge@~1.2.5:
     lodash.pad "^4.1.0"
     lodash.padend "^4.1.0"
     lodash.padstart "^4.1.0"
+
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
 
 get-caller-file@^1.0.1:
   version "1.0.2"
@@ -1558,17 +1796,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^5.0.15:
-  version "5.0.15"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-5.0.15.tgz#1bc936b9e02f4a603fcc222ecf7633d30b8b93b1"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "2 || 3"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1664,6 +1892,10 @@ has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
 
+has-flag@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
+
 has-gulplog@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/has-gulplog/-/has-gulplog-0.1.0.tgz#6414c82913697da51590397dafb12f22967811ce"
@@ -1673,6 +1905,12 @@ has-gulplog@^0.1.0:
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has@^1.0.1, has@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 hawk@~3.1.3:
   version "3.1.3"
@@ -1727,17 +1965,13 @@ iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
 
-iconv-lite@~0.4.13:
+iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
-image-size@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.3.5.tgz#83240eab2fb5b00b04aab8c74b0471e9cba7ad8c"
-
-immutable@~3.7.6:
-  version "3.7.6"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+image-size@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.1.tgz#98122a562d59dcc097ef1b2c8191866eb8f5d663"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -1750,26 +1984,31 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
-inquirer@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-0.12.0.tgz#1ef2bfd63504df0bc75785fff8c2c41df12f077e"
+ini@~1.3.0:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
+inquirer@^3.0.6:
+  version "3.2.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.2.3.tgz#1c7b1731cf77b934ec47d22c9ac5aa8fe7fbe095"
   dependencies:
-    ansi-escapes "^1.1.0"
-    ansi-regex "^2.0.0"
-    chalk "^1.0.0"
-    cli-cursor "^1.0.1"
+    ansi-escapes "^2.0.0"
+    chalk "^2.0.0"
+    cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    figures "^1.3.5"
+    external-editor "^2.0.4"
+    figures "^2.0.0"
     lodash "^4.3.0"
-    readline2 "^1.0.1"
-    run-async "^0.1.0"
-    rx-lite "^3.1.2"
-    string-width "^1.0.1"
-    strip-ansi "^3.0.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx-lite "^4.0.8"
+    rx-lite-aggregates "^4.0.8"
+    string-width "^2.1.0"
+    strip-ansi "^4.0.0"
     through "^2.3.6"
 
 invariant@^2.2.0:
@@ -1796,11 +2035,19 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
 is-ci@^1.0.9:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
     ci-info "^1.0.0"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -1832,6 +2079,14 @@ is-fullwidth-code-point@^1.0.0:
   dependencies:
     number-is-nan "^1.0.0"
 
+is-fullwidth-code-point@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-function@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
+
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
@@ -1858,9 +2113,23 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1877,10 +2146,6 @@ isarray@0.0.1:
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
-
-isemail@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2024,6 +2289,18 @@ jest-diff@^19.0.0:
     jest-matcher-utils "^19.0.0"
     pretty-format "^19.0.0"
 
+jest-docblock@20.1.0-chi.1:
+  version "20.1.0-chi.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-chi.1.tgz#06981ab0e59498a2492333b0c5502a82e4603207"
+
+jest-docblock@20.1.0-delta.4:
+  version "20.1.0-delta.4"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-delta.4.tgz#360d4f5fb702730c4136c4e71e5706188a694682"
+
+jest-docblock@^20.1.0-chi.1:
+  version "20.1.0-echo.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-echo.1.tgz#be02f43ee019f97e6b83267c746ac7b40d290fe8"
+
 jest-environment-jsdom@^19.0.2:
   version "19.0.2"
   resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-19.0.2.tgz#ceda859c4a4b94ab35e4de7dab54b926f293e4a3"
@@ -2043,14 +2320,26 @@ jest-file-exists@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-file-exists/-/jest-file-exists-19.0.0.tgz#cca2e587a11ec92e24cfeab3f8a94d657f3fceb8"
 
-jest-haste-map@18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-18.0.0.tgz#707d3b5ae3bcbda971c39e8b911d20ad8502c748"
+jest-haste-map@20.1.0-chi.1:
+  version "20.1.0-chi.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-chi.1.tgz#db5f5f31362c76e242b40ea9a3ccfa364719cee3"
   dependencies:
-    fb-watchman "^1.9.0"
-    graceful-fs "^4.1.6"
-    multimatch "^2.1.0"
-    sane "~1.4.1"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "^20.1.0-chi.1"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+    worker-farm "^1.3.1"
+
+jest-haste-map@20.1.0-delta.4:
+  version "20.1.0-delta.4"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-delta.4.tgz#12e32b297a6dd49705cacde938029fc158834006"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "20.1.0-delta.4"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
     worker-farm "^1.3.1"
 
 jest-haste-map@^19.0.0:
@@ -2178,15 +2467,6 @@ jest@19.0.2:
   dependencies:
     jest-cli "^19.0.2"
 
-joi@^6.6.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
-  dependencies:
-    hoek "2.x.x"
-    isemail "1.x.x"
-    moment "2.x.x"
-    topo "1.x.x"
-
 js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -2201,6 +2481,10 @@ js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jschardet@^1.4.2:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
 
 jsdom@^9.11.0:
   version "9.12.0"
@@ -2434,7 +2718,7 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.14.0, lodash@^4.16.6, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.14.0, lodash@^4.16.6, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -2442,7 +2726,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -2455,6 +2739,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+macos-release@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -2464,6 +2752,12 @@ makeerror@1.0.x:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+merge-stream@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-1.0.1.tgz#4041202d508a342ba00174008df0c251b8c135e1"
+  dependencies:
+    readable-stream "^2.0.1"
 
 merge@^1.1.3:
   version "1.2.0"
@@ -2481,6 +2775,46 @@ method-override@~2.3.5:
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+
+metro-bundler@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/metro-bundler/-/metro-bundler-0.11.0.tgz#ba5d2ae34943da28a37c2098047ad265c16fddf4"
+  dependencies:
+    absolute-path "^0.0.0"
+    async "^2.4.0"
+    babel-core "^6.24.1"
+    babel-generator "^6.24.1"
+    babel-plugin-external-helpers "^6.18.0"
+    babel-preset-es2015-node "^6.1.1"
+    babel-preset-fbjs "^2.1.4"
+    babel-preset-react-native "^2.0.0"
+    babel-register "^6.24.1"
+    babylon "^6.17.0"
+    chalk "^1.1.1"
+    concat-stream "^1.6.0"
+    core-js "^2.2.2"
+    debug "^2.2.0"
+    denodeify "^1.2.1"
+    fbjs "0.8.12"
+    graceful-fs "^4.1.3"
+    image-size "^0.6.0"
+    jest-docblock "20.1.0-chi.1"
+    jest-haste-map "20.1.0-chi.1"
+    json-stable-stringify "^1.0.1"
+    json5 "^0.4.0"
+    left-pad "^1.1.3"
+    lodash "^4.16.6"
+    merge-stream "^1.0.1"
+    mime-types "2.1.11"
+    mkdirp "^0.5.1"
+    request "^2.79.0"
+    rimraf "^2.5.4"
+    source-map "^0.5.6"
+    temp "0.8.3"
+    throat "^4.1.0"
+    uglify-js "2.7.5"
+    write-file-atomic "^1.2.0"
+    xpipe "^1.0.5"
 
 micromatch@^2.1.5, micromatch@^2.3.11:
   version "2.3.11"
@@ -2528,13 +2862,17 @@ mime@^1.3.4:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.6.tgz#591d84d3653a6b0b4a3b9df8de5aa8108e72e5e0"
 
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
 min-document@^2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
   dependencies:
     dom-walk "^0.1.0"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -2544,7 +2882,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -2552,15 +2890,11 @@ minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
 
-mkdirp@^0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
-
-moment@2.x.x:
-  version "2.18.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
 morgan@~1.6.1:
   version "1.6.1"
@@ -2584,15 +2918,6 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-multimatch@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/multimatch/-/multimatch-2.1.0.tgz#9c7906a22fb4c02919e2f5f75161b4cdbd4b2a2b"
-  dependencies:
-    array-differ "^1.0.0"
-    array-union "^1.0.1"
-    arrify "^1.0.0"
-    minimatch "^3.0.0"
-
 multiparty@3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/multiparty/-/multiparty-3.3.2.tgz#35de6804dc19643e5249f3d3e3bdc6c8ce301d3f"
@@ -2606,9 +2931,13 @@ multipipe@^0.1.2:
   dependencies:
     duplexer2 "0.0.2"
 
-mute-stream@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nan@^2.3.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2642,9 +2971,27 @@ node-notifier@^5.0.1:
     shellwords "^0.1.0"
     which "^1.2.12"
 
-node-uuid@1.4.7:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/node-uuid/-/node-uuid-1.4.7.tgz#6da5a17668c4b3dd59623bda11cf7fa4c1f60a6f"
+node-pre-gyp@^0.6.36:
+  version "0.6.37"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz#3c872b236b2e266e4140578fe1ee88f693323a05"
+  dependencies:
+    mkdirp "^0.5.1"
+    nopt "^4.0.1"
+    npmlog "^4.0.2"
+    rc "^1.1.7"
+    request "^2.81.0"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tape "^4.6.3"
+    tar "^2.2.1"
+    tar-pack "^3.4.0"
+
+nopt@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
+  dependencies:
+    abbrev "1"
+    osenv "^0.1.4"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -2669,6 +3016,15 @@ npmlog@^2.0.4:
     are-we-there-yet "~1.1.2"
     gauge "~1.2.5"
 
+npmlog@^4.0.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
+
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
@@ -2685,9 +3041,17 @@ object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-inspect@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2706,15 +3070,17 @@ on-headers@~1.0.0, on-headers@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.1.tgz#928f5d0f470d49342651ea6794b0857c100693f7"
 
-once@^1.3.0, once@^1.4.0:
+once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
 
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
+onetime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
+  dependencies:
+    mimic-fn "^1.0.0"
 
 opn@^3.0.2:
   version "3.0.3"
@@ -2754,9 +3120,23 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
-os-tmpdir@^1.0.0, os-tmpdir@^1.0.1:
+os-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
+  dependencies:
+    macos-release "^1.0.0"
+    win-release "^1.0.0"
+
+os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+
+osenv@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
+  dependencies:
+    os-homedir "^1.0.0"
+    os-tmpdir "^1.0.0"
 
 p-limit@^1.1.0:
   version "1.1.0"
@@ -2821,9 +3201,9 @@ pause@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/pause/-/pause-0.1.0.tgz#ebc8a4a8619ff0b8a81ac1513c3434ff469fdb74"
 
-pegjs@0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.9.0.tgz#f6aefa2e3ce56169208e52179dfe41f89141a369"
+pegjs@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/pegjs/-/pegjs-0.10.0.tgz#cf8bafae6eddff4b5a7efb185269eaaf4610ddbd"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -2843,7 +3223,15 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
 
-plist@1.2.0, plist@^1.2.0:
+plist@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/plist/-/plist-2.0.1.tgz#0a32ca9481b1c364e92e18dc55c876de9d01da8b"
+  dependencies:
+    base64-js "1.1.2"
+    xmlbuilder "8.2.2"
+    xmldom "0.1.x"
+
+plist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/plist/-/plist-1.2.0.tgz#084b5093ddc92506e259f874b8d9b1afb8c79593"
   dependencies:
@@ -2866,6 +3254,10 @@ pretty-format@^19.0.0:
   dependencies:
     ansi-styles "^3.0.0"
 
+pretty-format@^4.2.1:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-4.3.1.tgz#530be5c42b3c05b36414a7a2a4337aa80acd0e8d"
+
 private@^0.1.6:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.7.tgz#68ce5e8a1ef0a23bb570cc28537b5332aba63ef1"
@@ -2883,6 +3275,13 @@ promise@^7.1.1:
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
   dependencies:
     asap "~2.0.3"
+
+prop-types@^15.5.6, prop-types@^15.5.8:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -2927,6 +3326,15 @@ raw-body@~2.1.2:
     iconv-lite "0.4.13"
     unpipe "1.0.0"
 
+rc@^1.1.7:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
+  dependencies:
+    deep-extend "~0.4.0"
+    ini "~1.3.0"
+    minimist "^1.2.0"
+    strip-json-comments "~2.0.1"
+
 react-clone-referenced-element@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-clone-referenced-element/-/react-clone-referenced-element-1.0.1.tgz#2bba8c69404c5e4a944398600bcc4c941f860682"
@@ -2935,55 +3343,67 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-"react-native-branch@file:../..":
-  version "2.0.0-beta.8"
+react-devtools-core@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.5.0.tgz#5ad179f88f22d205940721e38e4ecc3a2d35bf03"
+  dependencies:
+    shell-quote "^1.6.1"
+    ws "^2.0.3"
 
-react-native@0.42.0:
-  version "0.42.0"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.42.0.tgz#59b501603a63232598fff653a36307a26010402e"
+"react-native-branch@file:../..":
+  version "2.0.1"
+
+react-native@0.48.2:
+  version "0.48.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.2.tgz#9907d5a73640ade3920701e7096fc109ba9cc6e4"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"
-    async "^2.0.1"
-    babel-core "^6.21.0"
-    babel-generator "^6.21.0"
+    async "^2.4.0"
+    babel-core "^6.24.1"
+    babel-generator "^6.24.1"
     babel-plugin-external-helpers "^6.18.0"
     babel-plugin-syntax-trailing-function-commas "^6.20.0"
+    babel-plugin-transform-async-to-generator "6.16.0"
+    babel-plugin-transform-class-properties "^6.18.0"
     babel-plugin-transform-flow-strip-types "^6.21.0"
     babel-plugin-transform-object-rest-spread "^6.20.2"
     babel-polyfill "^6.20.0"
     babel-preset-es2015-node "^6.1.1"
-    babel-preset-fbjs "^2.1.0"
-    babel-preset-react-native "^1.9.1"
-    babel-register "^6.18.0"
-    babel-runtime "^6.20.0"
-    babel-traverse "^6.21.0"
-    babel-types "^6.21.0"
-    babylon "^6.14.1"
+    babel-preset-fbjs "^2.1.4"
+    babel-preset-react-native "^2.0.0"
+    babel-register "^6.24.1"
+    babel-runtime "^6.23.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+    babylon "^6.17.0"
     base64-js "^1.1.2"
     bser "^1.0.2"
     chalk "^1.1.1"
     commander "^2.9.0"
+    concat-stream "^1.6.0"
     connect "^2.8.3"
     core-js "^2.2.2"
+    create-react-class "^15.5.2"
     debug "^2.2.0"
     denodeify "^1.2.1"
+    envinfo "^3.0.0"
+    errno ">=0.1.1 <0.2.0-0"
     event-target-shim "^1.0.5"
-    fbjs "^0.8.5"
+    fbjs "0.8.12"
     fbjs-scripts "^0.7.0"
-    fs-extra "^0.26.2"
-    glob "^5.0.15"
+    form-data "^2.1.1"
+    fs-extra "^1.0.0"
+    glob "^7.1.1"
     graceful-fs "^4.1.3"
-    image-size "^0.3.5"
-    immutable "~3.7.6"
-    imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    jest-haste-map "18.0.0"
-    joi "^6.6.1"
+    inquirer "^3.0.6"
+    jest-haste-map "20.1.0-delta.4"
     json-stable-stringify "^1.0.1"
     json5 "^0.4.0"
     left-pad "^1.1.3"
     lodash "^4.16.6"
+    merge-stream "^1.0.1"
+    metro-bundler "^0.11.0"
     mime "^1.3.4"
     mime-types "2.1.11"
     minimist "^1.2.0"
@@ -2993,8 +3413,11 @@ react-native@0.42.0:
     opn "^3.0.2"
     optimist "^0.6.1"
     plist "^1.2.0"
+    pretty-format "^4.2.1"
     promise "^7.1.1"
+    prop-types "^15.5.8"
     react-clone-referenced-element "^1.0.1"
+    react-devtools-core "^2.5.0"
     react-timer-mixin "^0.13.2"
     react-transform-hmr "^1.0.4"
     rebound "^0.0.13"
@@ -3007,15 +3430,15 @@ react-native@0.42.0:
     source-map "^0.5.6"
     stacktrace-parser "^0.1.3"
     temp "0.8.3"
-    throat "^3.0.0"
-    uglify-js "^2.6.2"
+    throat "^4.1.0"
     whatwg-fetch "^1.0.0"
     wordwrap "^1.0.0"
-    worker-farm "^1.3.1"
     write-file-atomic "^1.2.0"
     ws "^1.1.0"
-    xcode "^0.8.9"
+    xcode "^0.9.1"
     xmldoc "^0.4.0"
+    xpipe "^1.0.5"
+    xtend ">=4.0.0 <4.1.0-0"
     yargs "^6.4.0"
 
 react-proxy@^1.1.7:
@@ -3043,13 +3466,15 @@ react-transform-hmr@^1.0.4:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react@~15.4.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.4.2.tgz#41f7991b26185392ba9bae96c8889e7e018397ef"
+react@16.0.0-alpha.12:
+  version "16.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0-alpha.12.tgz#8c59485281485df319b6f77682d8dd0621c08194"
   dependencies:
-    fbjs "^0.8.4"
+    create-react-class "^15.5.2"
+    fbjs "^0.8.9"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+    prop-types "^15.5.6"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3066,7 +3491,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.6, readable-stream@^2.1.5:
+readable-stream@^2.0.1, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
   dependencies:
@@ -3087,14 +3512,6 @@ readable-stream@~1.1.8, readable-stream@~1.1.9:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readline2@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/readline2/-/readline2-1.0.1.tgz#41059608ffc154757b715d9989d199ffbf372e35"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    mute-stream "0.0.5"
-
 rebound@^0.0.13:
   version "0.0.13"
   resolved "https://registry.yarnpkg.com/rebound/-/rebound-0.0.13.tgz#4a225254caf7da756797b19c5817bf7a7941fac1"
@@ -3106,6 +3523,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-runtime@^0.9.5:
   version "0.9.6"
@@ -3166,7 +3587,7 @@ replace-ext@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-0.0.1.tgz#29bbd92078a739f0bcce2b4ee41e837953522924"
 
-request@^2.79.0:
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -3205,7 +3626,7 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.2.0:
+resolve@^1.2.0, resolve@~1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
@@ -3218,12 +3639,18 @@ response-time@~2.3.1:
     depd "~1.1.0"
     on-headers "~1.0.1"
 
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
   dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
+resumer@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  dependencies:
+    through "~2.3.4"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3231,7 +3658,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
   dependencies:
@@ -3245,19 +3672,43 @@ rndm@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/rndm/-/rndm-1.2.0.tgz#f33fe9cfb52bbfd520aa18323bc65db110a1b76c"
 
-run-async@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
+run-async@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.3.0.tgz#0371ab4ae0bdd720d4166d7dfda64ff7a445a6c0"
   dependencies:
-    once "^1.3.0"
+    is-promise "^2.1.0"
 
-rx-lite@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
+rx-lite-aggregates@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
+  dependencies:
+    rx-lite "*"
+
+rx-lite@*, rx-lite@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
 safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-buffer@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+sane@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sane/-/sane-2.0.0.tgz#99cb79f21f4a53a69d4d0cd957c2db04024b8eb2"
+  dependencies:
+    anymatch "^1.3.0"
+    exec-sh "^0.2.0"
+    fb-watchman "^2.0.0"
+    minimatch "^3.0.2"
+    minimist "^1.1.1"
+    walker "~1.0.5"
+    watch "~0.10.0"
+  optionalDependencies:
+    fsevents "^1.1.1"
 
 sane@~1.4.1:
   version "1.4.1"
@@ -3290,7 +3741,7 @@ sax@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
 
-"semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
@@ -3340,7 +3791,7 @@ serve-static@~1.10.0:
     parseurl "~1.3.1"
     send "0.13.2"
 
-set-blocking@^2.0.0:
+set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
 
@@ -3348,7 +3799,7 @@ setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
 
-shell-quote@1.6.1:
+shell-quote@1.6.1, shell-quote@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.6.1.tgz#f4781949cce402697127430ea3b3c5476f481767"
   dependencies:
@@ -3361,13 +3812,17 @@ shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
-simple-plist@0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-0.1.4.tgz#10eb51b47e33c556eb8ec46d5ee64d64e717db5d"
+signal-exit@^3.0.0, signal-exit@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-plist@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/simple-plist/-/simple-plist-0.2.1.tgz#71766db352326928cf3a807242ba762322636723"
   dependencies:
-    bplist-creator "0.0.4"
-    bplist-parser "0.0.6"
-    plist "1.2.0"
+    bplist-creator "0.0.7"
+    bplist-parser "0.1.1"
+    plist "2.0.1"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3453,9 +3908,9 @@ statuses@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.2.1.tgz#dded45cc18256d51ed40aec142489d5c61026d28"
 
-stream-buffers@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-0.2.6.tgz#181c08d5bb3690045f69401b9ae6a7a0cf3313fc"
+stream-buffers@~2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/stream-buffers/-/stream-buffers-2.2.0.tgz#91d5f5130d1cef96dcfa7f726945188741d09ee4"
 
 stream-counter@~0.2.0:
   version "0.2.0"
@@ -3477,6 +3932,21 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
+string-width@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^4.0.0"
+
+string.prototype.trim@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -3497,6 +3967,12 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
+
 strip-bom@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -3506,6 +3982,10 @@ strip-bom@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
 supports-color@^2.0.0:
   version "2.0.0"
@@ -3517,9 +3997,54 @@ supports-color@^3.1.2:
   dependencies:
     has-flag "^1.0.0"
 
+supports-color@^4.0.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
+  dependencies:
+    has-flag "^2.0.0"
+
 symbol-tree@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+
+tape@^4.6.3:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.8.0.tgz#f6a9fec41cc50a1de50fa33603ab580991f6068e"
+  dependencies:
+    deep-equal "~1.0.1"
+    defined "~1.0.0"
+    for-each "~0.3.2"
+    function-bind "~1.1.0"
+    glob "~7.1.2"
+    has "~1.0.1"
+    inherits "~2.0.3"
+    minimist "~1.2.0"
+    object-inspect "~1.3.0"
+    resolve "~1.4.0"
+    resumer "~0.0.0"
+    string.prototype.trim "~1.1.2"
+    through "~2.3.8"
+
+tar-pack@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/tar-pack/-/tar-pack-3.4.0.tgz#23be2d7f671a8339376cbdb0b8fe3fdebf317984"
+  dependencies:
+    debug "^2.2.0"
+    fstream "^1.0.10"
+    fstream-ignore "^1.0.5"
+    once "^1.3.3"
+    readable-stream "^2.1.4"
+    rimraf "^2.5.1"
+    tar "^2.2.1"
+    uid-number "^0.0.6"
+
+tar@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
+  dependencies:
+    block-stream "*"
+    fstream "^1.0.2"
+    inherits "2"
 
 temp@0.8.3:
   version "0.8.3"
@@ -3542,6 +4067,10 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
+throat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -3549,7 +4078,7 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@^2.3.6:
+through@^2.3.6, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -3557,19 +4086,19 @@ time-stamp@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-1.1.0.tgz#764a5a11af50561921b133f3b44e618687e0f5c3"
 
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
 tmpl@1.0.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/tmpl/-/tmpl-1.0.4.tgz#23640dd7b42d00433911140820e5cf440e521dd1"
 
-to-fast-properties@^1.0.1:
+to-fast-properties@^1.0.1, to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-
-topo@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
-  dependencies:
-    hoek "2.x.x"
 
 tough-cookie@^2.3.2, tough-cookie@~2.3.0:
   version "2.3.2"
@@ -3612,11 +4141,24 @@ type-is@~1.6.6:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
+typedarray@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
+
 ua-parser-js@^0.7.9:
   version "0.7.14"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
 
-uglify-js@^2.6, uglify-js@^2.6.2:
+uglify-js@2.7.5:
+  version "2.7.5"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.5.tgz#4612c0c7baaee2ba7c487de4904ae122079f2ca8"
+  dependencies:
+    async "~0.2.6"
+    source-map "~0.5.1"
+    uglify-to-browserify "~1.0.0"
+    yargs "~3.10.0"
+
+uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   dependencies:
@@ -3628,6 +4170,10 @@ uglify-js@^2.6, uglify-js@^2.6.2:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+uid-number@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
 
 uid-safe@2.1.4:
   version "2.1.4"
@@ -3645,6 +4191,10 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+ultron@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.0.tgz#b07a2e6a541a815fc6a34ccd4533baec307ca864"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -3656,6 +4206,10 @@ util-deprecate@1.0.2, util-deprecate@~1.0.1:
 utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
+
+uuid@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.0.1.tgz#6544bba2dfda8c1cf17e629a3a305e2bb1fee6c1"
 
 uuid@^3.0.0:
   version "3.1.0"
@@ -3739,11 +4293,23 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.1.1, which@^1.2.12, which@^1.2.9:
+which@^1.1.1, which@^1.2.12, which@^1.2.14, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
     isexe "^2.0.0"
+
+wide-align@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
+  dependencies:
+    string-width "^1.0.2"
+
+win-release@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
+  dependencies:
+    semver "^5.0.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -3794,13 +4360,20 @@ ws@^1.1.0:
     options ">=0.0.5"
     ultron "1.0.x"
 
-xcode@^0.8.9:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.8.9.tgz#ec6765f70e9dccccc9f6e9a5b9b4e7e814b4cf35"
+ws@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-2.3.1.tgz#6b94b3e447cb6a363f785eaf94af6359e8e81c80"
   dependencies:
-    node-uuid "1.4.7"
-    pegjs "0.9.0"
-    simple-plist "0.1.4"
+    safe-buffer "~5.0.1"
+    ultron "~1.1.0"
+
+xcode@^0.9.1:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/xcode/-/xcode-0.9.3.tgz#910a89c16aee6cc0b42ca805a6d0b4cf87211cf3"
+  dependencies:
+    pegjs "^0.10.0"
+    simple-plist "^0.2.1"
+    uuid "3.0.1"
 
 xml-name-validator@^2.0.1:
   version "2.0.1"
@@ -3812,6 +4385,10 @@ xmlbuilder@4.0.0:
   dependencies:
     lodash "^3.5.0"
 
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+
 xmldoc@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/xmldoc/-/xmldoc-0.4.0.tgz#d257224be8393eaacbf837ef227fd8ec25b36888"
@@ -3822,7 +4399,11 @@ xmldom@0.1.x:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
 
-xtend@^4.0.1, xtend@~4.0.1:
+xpipe@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/xpipe/-/xpipe-1.0.5.tgz#8dd8bf45fc3f7f55f0e054b878f43a62614dafdf"
+
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 

--- a/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
+++ b/examples/webview_example/ios/webview_example.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		AA8672A99CFA4DDA859E91F8 /* libreact-native-branch.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 68E701F464B742F4826AA73F /* libreact-native-branch.a */; };
 		C9882AD89BCF4A4596207F76 /* branch.debug.json in Resources */ = {isa = PBXBuildFile; fileRef = 792CF918D8A949C59E650130 /* branch.debug.json */; };
+		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -268,6 +269,13 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		ADBDB9261DFEBF0700ED6528 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 358F4ED71D1E81A9004DF814;
+			remoteInfo = RCTBlob;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -302,6 +310,7 @@
 		7BC69F431EA12D87000B04CE /* webview_example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = webview_example.entitlements; path = webview_example/webview_example.entitlements; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		A87EEEF52AF84B8283D19A55 /* RNBranch.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNBranch.xcodeproj; path = "../node_modules/react-native-branch/ios/RNBranch.xcodeproj"; sourceTree = "<group>"; };
+		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -320,6 +329,8 @@
 				7BAA95041F57633100C57B54 /* SafariServices.framework in Frameworks */,
 				7BAA95031F57632800C57B54 /* AdSupport.framework in Frameworks */,
 				7BAA94CE1F57608000C57B54 /* CoreSpotlight.framework in Frameworks */,
+				ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */,
+				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				146834051AC3E58100842450 /* libReact.a in Frameworks */,
 				5E9157361DD0AC6A00FF2AA8 /* libRCTAnimation.a in Frameworks */,
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
@@ -514,6 +525,7 @@
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
 				00C302A71ABCB8CE00DB3ED1 /* RCTActionSheet.xcodeproj */,
+				ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */,
 				00C302B51ABCB90400DB3ED1 /* RCTGeolocation.xcodeproj */,
 				00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */,
 				78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */,
@@ -548,6 +560,7 @@
 			indentWidth = 2;
 			sourceTree = "<group>";
 			tabWidth = 2;
+			usesTabs = 0;
 		};
 		83CBBA001A601CBA00E9B192 /* Products */ = {
 			isa = PBXGroup;
@@ -556,6 +569,14 @@
 				00E356EE1AD99517003FC87E /* webview_exampleTests.xctest */,
 				2D02E47B1E0B4A5D006451C7 /* webview_example-tvOS.app */,
 				2D02E4901E0B4A5D006451C7 /* webview_example-tvOSTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		ADBDB9201DFEBF0600ED6528 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -687,6 +708,10 @@
 				{
 					ProductGroup = 5E91572E1DD0AC6500FF2AA8 /* Products */;
 					ProjectRef = 5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */;
+				},
+				{
+					ProductGroup = ADBDB9201DFEBF0600ED6528 /* Products */;
+					ProjectRef = ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */;
 				},
 				{
 					ProductGroup = 00C302B61ABCB90400DB3ED1 /* Products */;
@@ -838,10 +863,10 @@
 			remoteRef = 3DAD3E981DF850E9000B6D8A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		3DAD3EA31DF850E9000B6D8A /* libReact.a */ = {
+		3DAD3EA31DF850E9000B6D8A /* libReact-tvOS.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
-			path = libReact.a;
+			path = "libReact-tvOS.a";
 			remoteRef = 3DAD3EA21DF850E9000B6D8A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
@@ -948,6 +973,13 @@
 			fileType = archive.ar;
 			path = libRCTText.a;
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTBlob.a;
+			remoteRef = ADBDB9261DFEBF0700ED6528 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/examples/webview_example/package-lock.json
+++ b/examples/webview_example/package-lock.json
@@ -5424,9 +5424,9 @@
       }
     },
     "react-test-renderer": {
-      "version": "15.4.2",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-15.4.2.tgz",
-      "integrity": "sha1-J+Hf9dJtDoMPmWFMSHYivIMUFvM=",
+      "version": "16.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.0.0-alpha.12.tgz",
+      "integrity": "sha1-nkzF2M6L/KcneDQN4+FFS51sDMU=",
       "dev": true,
       "requires": {
         "fbjs": "0.8.15",

--- a/examples/webview_example/package-lock.json
+++ b/examples/webview_example/package-lock.json
@@ -433,7 +433,7 @@
       "dev": true,
       "requires": {
         "find-up": "2.1.0",
-        "istanbul-lib-instrument": "1.7.5",
+        "istanbul-lib-instrument": "1.8.0",
         "test-exclude": "4.1.1"
       },
       "dependencies": {
@@ -770,14 +770,14 @@
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "requires": {
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
         },
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -890,17 +890,17 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.16"
+        "source-map-support": "0.4.17"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
         }
       }
     },
@@ -909,14 +909,14 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
         },
         "regenerator-runtime": {
           "version": "0.11.0",
@@ -1014,9 +1014,9 @@
       "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
     },
     "big-integer": {
-      "version": "1.6.24",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.24.tgz",
-      "integrity": "sha1-HthNAYrDwccrMH5/fZQAjo7iAxE="
+      "version": "1.6.25",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.25.tgz",
+      "integrity": "sha1-HeRan1dUKsIBIcaC+NZCIgo06CM="
     },
     "body-parser": {
       "version": "1.13.3",
@@ -1076,7 +1076,7 @@
       "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.1.1.tgz",
       "integrity": "sha1-1g1dzCDLptx+HymbNdPh+V2vuuY=",
       "requires": {
-        "big-integer": "1.6.24"
+        "big-integer": "1.6.25"
       }
     },
     "brace-expansion": {
@@ -1171,9 +1171,9 @@
       }
     },
     "ci-info": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.0.0.tgz",
-      "integrity": "sha1-3FKF8rTiUYIWg2gcOBwziPRuxTQ=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
       "dev": true
     },
     "cli-cursor": {
@@ -1257,7 +1257,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
       "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "1.30.0"
       }
     },
     "compression": {
@@ -1437,7 +1437,7 @@
       "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
       "integrity": "sha1-q0SEl8JlZuHilBPogyB9V8/nvtQ=",
       "requires": {
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.15",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1"
       }
@@ -1577,9 +1577,9 @@
       }
     },
     "diff": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
-      "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
       "dev": true
     },
     "dom-walk": {
@@ -1640,6 +1640,16 @@
         "iconv-lite": "0.4.18"
       }
     },
+    "envinfo": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-3.4.1.tgz",
+      "integrity": "sha1-jIDp8u7CzU4q2yxdASfOB6Kqoq4=",
+      "requires": {
+        "minimist": "1.2.0",
+        "os-name": "2.0.1",
+        "which": "1.3.0"
+      }
+    },
     "errno": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
@@ -1670,16 +1680,16 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
           "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
           "requires": {
-            "mime-types": "2.1.16",
+            "mime-types": "2.1.17",
             "negotiator": "0.6.1"
           }
         },
         "mime-types": {
-          "version": "2.1.16",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-          "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "1.30.0"
           }
         },
         "negotiator": {
@@ -1700,33 +1710,23 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
         }
       }
     },
@@ -1737,9 +1737,9 @@
       "dev": true
     },
     "estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -1758,9 +1758,9 @@
       "integrity": "sha1-qG5e5r2qFgVEddp5fM3fDFVphJE="
     },
     "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "requires": {
         "merge": "1.2.0"
       }
@@ -1882,9 +1882,9 @@
       }
     },
     "fbjs": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
-      "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.15.tgz",
+      "integrity": "sha1-TwaV/fzBbDfAsH+s7Iy0xAkWhbk=",
       "requires": {
         "core-js": "1.2.7",
         "isomorphic-fetch": "2.2.1",
@@ -2043,15 +2043,15 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "mime-types": "2.1.17"
       },
       "dependencies": {
         "mime-types": {
-          "version": "2.1.16",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-          "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "1.30.0"
           }
         }
       }
@@ -3129,9 +3129,9 @@
       "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA=="
     },
     "image-size": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz",
-      "integrity": "sha1-gyQOqy+1sAsEqrjHSwRx6cunrYw="
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.1.tgz",
+      "integrity": "sha512-lHMlI2MykfeHAQdtydQh4fTcBQVf4zLTA91w1euBe9rbmAfJ/iyzMh8H3KD9u1RldlHaMS3tmMV5TEe9BkmW9g=="
     },
     "immutable": {
       "version": "3.7.6",
@@ -3158,9 +3158,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.2.tgz",
-      "integrity": "sha512-bTKLzEHJVATimZO/YFdLrom0lRx1BHfRYskFHfIMVkGdp8+dIZaxuU+4yrsS1lcu6YWywVQVVsfvdwESzbeqHw==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.3.tgz",
+      "integrity": "sha512-Bc3KbimpDTOeQdDj18Ir/rlsGuhBSSNqdOnxaAuKhpkdnMMuKsEGbZD2v5KFF9oso2OU+BPh7+/u5obmFDRmWw==",
       "requires": {
         "ansi-escapes": "2.0.0",
         "chalk": "2.1.0",
@@ -3198,7 +3198,7 @@
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.2.1"
+            "supports-color": "4.4.0"
           }
         },
         "strip-ansi": {
@@ -3210,9 +3210,9 @@
           }
         },
         "supports-color": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-          "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -3256,7 +3256,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.0.0"
+        "ci-info": "1.1.1"
       }
     },
     "is-dotfile": {
@@ -3364,7 +3364,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
       "requires": {
-        "node-fetch": "1.7.2",
+        "node-fetch": "1.7.3",
         "whatwg-fetch": "2.0.3"
       }
     },
@@ -3374,16 +3374,16 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.13.tgz",
-      "integrity": "sha1-cZf2RBNgDr3+xjR6LcPU4D+X7Vo=",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.1.14.tgz",
+      "integrity": "sha1-JbxXAffGgMD//5E95G42GaOm5oA=",
       "dev": true,
       "requires": {
         "async": "2.5.0",
         "fileset": "2.0.3",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-hook": "1.0.7",
-        "istanbul-lib-instrument": "1.7.5",
+        "istanbul-lib-instrument": "1.8.0",
         "istanbul-lib-report": "1.1.1",
         "istanbul-lib-source-maps": "1.2.1",
         "istanbul-reports": "1.1.2",
@@ -3408,9 +3408,9 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.5.tgz",
-      "integrity": "sha1-rbWW+PDLi5XnOSBjUaOKWGryGx4=",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.8.0.tgz",
+      "integrity": "sha1-ZvbJQhzJ7EcE928tsIS6kHiitTI=",
       "dev": true,
       "requires": {
         "babel-generator": "6.26.0",
@@ -3508,9 +3508,9 @@
             "chalk": "1.1.3",
             "graceful-fs": "4.1.11",
             "is-ci": "1.0.10",
-            "istanbul-api": "1.1.13",
+            "istanbul-api": "1.1.14",
             "istanbul-lib-coverage": "1.1.1",
-            "istanbul-lib-instrument": "1.7.5",
+            "istanbul-lib-instrument": "1.8.0",
             "jest-changed-files": "19.0.2",
             "jest-config": "19.0.4",
             "jest-environment-jsdom": "19.0.2",
@@ -3552,7 +3552,7 @@
           "dev": true,
           "requires": {
             "anymatch": "1.3.2",
-            "exec-sh": "0.2.0",
+            "exec-sh": "0.2.1",
             "fb-watchman": "1.9.2",
             "minimatch": "3.0.4",
             "minimist": "1.2.0",
@@ -3570,6 +3570,12 @@
               }
             }
           }
+        },
+        "throat": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+          "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+          "dev": true
         }
       }
     },
@@ -3622,7 +3628,7 @@
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
-        "diff": "3.3.0",
+        "diff": "3.3.1",
         "jest-matcher-utils": "19.0.0",
         "pretty-format": "19.0.0"
       },
@@ -3648,9 +3654,9 @@
       }
     },
     "jest-docblock": {
-      "version": "20.1.0-echo.1",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.1.0-echo.1.tgz",
-      "integrity": "sha512-zJPqHgxSlu5AYjyFLoXzwSqTZGeRAbtW9lTrWfjfDWyQCQjPlt9j9s7t3UBoDwUocM7qVNdlrcXPPtBkQR1dJw=="
+      "version": "20.1.0-delta.4",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.1.0-delta.4.tgz",
+      "integrity": "sha512-apbBKyQ8ET8XQbOnsjIYTvmo2+FRZIsxUkfy75IbG+SH9ILQLjEfPXq3B/iMRCGoTAeI8lwxUQoLKGbw0mrTCQ=="
     },
     "jest-environment-jsdom": {
       "version": "19.0.2",
@@ -3680,13 +3686,13 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "20.1.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.1.0-alpha.3.tgz",
-      "integrity": "sha512-3df1aahjWeK6pcpahjbZpa4zz6aE4DwDZE8/vB9IWHB9Lvnj2fHFovxMRAr32vWKPQ6VTzwNhI4nCuolQGGXPw==",
+      "version": "20.1.0-delta.4",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.1.0-delta.4.tgz",
+      "integrity": "sha512-L95f3nYoxUSzqzJdOq39ggklspwkqOq/FkzvH0SYhXdpv0c0kW8DXLovxfZy5FnK4rUyeVMBI9aNQ+TvZHKT3Q==",
       "requires": {
         "fb-watchman": "2.0.0",
         "graceful-fs": "4.1.11",
-        "jest-docblock": "20.1.0-echo.1",
+        "jest-docblock": "20.1.0-delta.4",
         "micromatch": "2.3.11",
         "sane": "2.0.0",
         "worker-farm": "1.5.0"
@@ -3698,7 +3704,7 @@
           "integrity": "sha1-mct58h9KU6adTQzZV8LbBAJLjrI=",
           "requires": {
             "anymatch": "1.3.2",
-            "exec-sh": "0.2.0",
+            "exec-sh": "0.2.1",
             "fb-watchman": "2.0.0",
             "fsevents": "1.1.2",
             "minimatch": "3.0.4",
@@ -3826,7 +3832,7 @@
           "dev": true,
           "requires": {
             "anymatch": "1.3.2",
-            "exec-sh": "0.2.0",
+            "exec-sh": "0.2.1",
             "fb-watchman": "1.9.2",
             "minimatch": "3.0.4",
             "minimist": "1.2.0",
@@ -3908,7 +3914,7 @@
           "dev": true,
           "requires": {
             "anymatch": "1.3.2",
-            "exec-sh": "0.2.0",
+            "exec-sh": "0.2.1",
             "fb-watchman": "1.9.2",
             "minimatch": "3.0.4",
             "minimist": "1.2.0",
@@ -4057,7 +4063,7 @@
         "content-type-parser": "1.0.1",
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
-        "escodegen": "1.8.1",
+        "escodegen": "1.9.0",
         "html-encoding-sniffer": "1.0.1",
         "nwmatcher": "1.4.1",
         "parse5": "1.5.1",
@@ -4363,6 +4369,11 @@
         "yallist": "2.1.2"
       }
     },
+    "macos-release": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+      "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA=="
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -4413,9 +4424,9 @@
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "metro-bundler": {
-      "version": "0.9.2",
-      "resolved": "https://registry.npmjs.org/metro-bundler/-/metro-bundler-0.9.2.tgz",
-      "integrity": "sha512-55x+GoT70a99UcTt+/i/ItJm+emLacT5abOv1XV8Y5la3X62ijie3WzVrkWd9l3evMXqJnt/muuoG79vuAezpg==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/metro-bundler/-/metro-bundler-0.11.0.tgz",
+      "integrity": "sha512-z1b2HtOa1uJVrp5KOx9bvoYRPD8Gn5x+gyFTIGSev7hbDzyAmUoooFUf8yLAfyIVIb4TZGB+tjkn+Skmn41aNQ==",
       "requires": {
         "absolute-path": "0.0.0",
         "async": "2.5.0",
@@ -4424,18 +4435,19 @@
         "babel-plugin-external-helpers": "6.22.0",
         "babel-preset-es2015-node": "6.1.1",
         "babel-preset-fbjs": "2.1.4",
-        "babel-preset-react-native": "1.9.2",
+        "babel-preset-react-native": "2.1.0",
         "babel-register": "6.26.0",
         "babylon": "6.18.0",
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "debug": "2.6.8",
         "denodeify": "1.2.1",
         "fbjs": "0.8.12",
         "graceful-fs": "4.1.11",
-        "image-size": "0.3.5",
-        "jest-haste-map": "20.0.4",
+        "image-size": "0.6.1",
+        "jest-docblock": "20.1.0-chi.1",
+        "jest-haste-map": "20.1.0-chi.1",
         "json-stable-stringify": "1.0.1",
         "json5": "0.4.0",
         "left-pad": "1.1.3",
@@ -4447,16 +4459,16 @@
         "rimraf": "2.6.1",
         "source-map": "0.5.7",
         "temp": "0.8.3",
-        "throat": "3.2.0",
+        "throat": "4.1.0",
         "uglify-js": "2.7.5",
         "write-file-atomic": "1.3.4",
         "xpipe": "1.0.5"
       },
       "dependencies": {
         "babel-preset-react-native": {
-          "version": "1.9.2",
-          "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-1.9.2.tgz",
-          "integrity": "sha1-sird0uNV/zs5Zxt5voB+Ut+hRfI=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-react-native/-/babel-preset-react-native-2.1.0.tgz",
+          "integrity": "sha1-kBPr2C2hyIECv1iIEP9Z4gnKK4o=",
           "requires": {
             "babel-plugin-check-es2015-constants": "6.22.0",
             "babel-plugin-react-transform": "2.0.2",
@@ -4489,18 +4501,10 @@
             "react-transform-hmr": "1.0.4"
           }
         },
-        "bser": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
-          "integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
-          "requires": {
-            "node-int64": "0.4.0"
-          }
-        },
         "core-js": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
         },
         "fbjs": {
           "version": "0.8.12",
@@ -4524,45 +4528,36 @@
           }
         },
         "jest-docblock": {
-          "version": "20.0.3",
-          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.0.3.tgz",
-          "integrity": "sha1-F76phDQswz2DxQ++FUXqDvqkRxI="
+          "version": "20.1.0-chi.1",
+          "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-20.1.0-chi.1.tgz",
+          "integrity": "sha512-zX64LtNgTgphO06akqDxKQhVET3uwjZTRalqG2jJoWyEdSUYGp8yjjqicJ7rRu5ZbwnuaB8yqqP9Exu59oDNaA=="
         },
         "jest-haste-map": {
-          "version": "20.0.4",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.0.4.tgz",
-          "integrity": "sha1-ZT61XIic48Ah97lGk/IKQVm63wM=",
+          "version": "20.1.0-chi.1",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-20.1.0-chi.1.tgz",
+          "integrity": "sha512-G5Bjy3NoSBOR4T5FGqu6VlUJk7BnGUfRXkPcU26HTE06j5T0HEnVoScUsP1+XHSSw0XKq84N2LquppHbg3buxg==",
           "requires": {
             "fb-watchman": "2.0.0",
             "graceful-fs": "4.1.11",
-            "jest-docblock": "20.0.3",
+            "jest-docblock": "20.1.0-chi.1",
             "micromatch": "2.3.11",
-            "sane": "1.6.0",
+            "sane": "2.0.0",
             "worker-farm": "1.5.0"
           }
         },
         "sane": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/sane/-/sane-1.6.0.tgz",
-          "integrity": "sha1-lhDEUjB6E10pwf3+JUcDQYDEZ3U=",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/sane/-/sane-2.0.0.tgz",
+          "integrity": "sha1-mct58h9KU6adTQzZV8LbBAJLjrI=",
           "requires": {
             "anymatch": "1.3.2",
-            "exec-sh": "0.2.0",
-            "fb-watchman": "1.9.2",
+            "exec-sh": "0.2.1",
+            "fb-watchman": "2.0.0",
+            "fsevents": "1.1.2",
             "minimatch": "3.0.4",
             "minimist": "1.2.0",
             "walker": "1.0.7",
             "watch": "0.10.0"
-          },
-          "dependencies": {
-            "fb-watchman": {
-              "version": "1.9.2",
-              "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-1.9.2.tgz",
-              "integrity": "sha1-okz0eCf4LTj7Waaa1wt247auc4M=",
-              "requires": {
-                "bser": "1.0.2"
-              }
-            }
           }
         }
       }
@@ -4584,7 +4579,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -4593,9 +4588,9 @@
       "integrity": "sha512-n9ChLv77+QQEapYz8lV+rIZAW3HhAPW2CXnzb1GN5uMkuczshwvkW7XPsbzU0ZQN3sP47Er2KVkp2p3KyqZKSQ=="
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
       "version": "2.1.11",
@@ -4748,9 +4743,9 @@
       "integrity": "sha1-Jp1cR2gQ7JLtvntsLygxY4T5p+g="
     },
     "node-fetch": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
-      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
       "requires": {
         "encoding": "0.1.12",
         "is-stream": "1.1.0"
@@ -4920,6 +4915,15 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "1.0.0"
+      }
+    },
+    "os-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+      "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+      "requires": {
+        "macos-release": "1.1.0",
+        "win-release": "1.1.1"
       }
     },
     "os-tmpdir": {
@@ -5096,7 +5100,7 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
       "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
       "requires": {
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.15",
         "loose-envify": "1.3.1"
       }
     },
@@ -5195,7 +5199,7 @@
       "integrity": "sha1-jFlIUoFIXfMZtvd2gtjdBiHAgZQ=",
       "requires": {
         "create-react-class": "15.6.0",
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.15",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
         "prop-types": "15.5.10"
@@ -5212,9 +5216,9 @@
       "integrity": "sha1-vNMUeAJ7ZLMznxCJIatSC0MT3Cw="
     },
     "react-devtools-core": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.3.1.tgz",
-      "integrity": "sha1-3IOrqFc17/5eHcOGoWFMtejQBH0=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-2.5.0.tgz",
+      "integrity": "sha512-sLlDHiY+DoOnzEXdLwSGxob3MtiIwM54s6FBbVAc/iOorNd8Nv1aVUTsZpTnJXDYa8p5VPNdCR4ATQ0HcIBh+Q==",
       "requires": {
         "shell-quote": "1.6.1",
         "ws": "2.3.1"
@@ -5237,9 +5241,9 @@
       }
     },
     "react-native": {
-      "version": "0.47.2",
-      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.47.2.tgz",
-      "integrity": "sha1-XlXNhOSUcSPIbTbqb5WrntLQyxk=",
+      "version": "0.48.2",
+      "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.48.2.tgz",
+      "integrity": "sha1-mQfVpzZAreOSBwHnCW/BCbqcxuQ=",
       "requires": {
         "absolute-path": "0.0.0",
         "art": "0.10.1",
@@ -5267,10 +5271,11 @@
         "commander": "2.11.0",
         "concat-stream": "1.6.0",
         "connect": "2.30.2",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "create-react-class": "15.6.0",
         "debug": "2.6.8",
         "denodeify": "1.2.1",
+        "envinfo": "3.4.1",
         "errno": "0.1.4",
         "event-target-shim": "1.1.1",
         "fbjs": "0.8.12",
@@ -5279,19 +5284,19 @@
         "fs-extra": "1.0.0",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "inquirer": "3.2.2",
-        "jest-haste-map": "20.1.0-alpha.3",
+        "inquirer": "3.2.3",
+        "jest-haste-map": "20.1.0-delta.4",
         "json-stable-stringify": "1.0.1",
         "json5": "0.4.0",
         "left-pad": "1.1.3",
         "lodash": "4.17.4",
         "merge-stream": "1.0.1",
-        "metro-bundler": "0.9.2",
+        "metro-bundler": "0.11.0",
         "mime": "1.4.0",
         "mime-types": "2.1.11",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "node-fetch": "1.7.2",
+        "node-fetch": "1.7.3",
         "npmlog": "2.0.4",
         "opn": "3.0.3",
         "optimist": "0.6.1",
@@ -5300,7 +5305,7 @@
         "promise": "7.3.1",
         "prop-types": "15.5.10",
         "react-clone-referenced-element": "1.0.1",
-        "react-devtools-core": "2.3.1",
+        "react-devtools-core": "2.5.0",
         "react-timer-mixin": "0.13.3",
         "react-transform-hmr": "1.0.4",
         "rebound": "0.0.13",
@@ -5313,7 +5318,7 @@
         "source-map": "0.5.7",
         "stacktrace-parser": "0.1.4",
         "temp": "0.8.3",
-        "throat": "3.2.0",
+        "throat": "4.1.0",
         "whatwg-fetch": "1.1.1",
         "wordwrap": "1.0.0",
         "write-file-atomic": "1.3.4",
@@ -5362,9 +5367,9 @@
           }
         },
         "core-js": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-          "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
         },
         "fbjs": {
           "version": "0.8.12",
@@ -5402,7 +5407,7 @@
       "resolved": "https://registry.npmjs.org/react-native-deprecated-custom-components/-/react-native-deprecated-custom-components-0.1.1.tgz",
       "integrity": "sha1-u5EfAb8vR/CpF2R1e/kY8yFulOk=",
       "requires": {
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.15",
         "immutable": "3.7.6",
         "prop-types": "15.5.10",
         "react-timer-mixin": "0.13.3",
@@ -5424,7 +5429,7 @@
       "integrity": "sha1-J+Hf9dJtDoMPmWFMSHYivIMUFvM=",
       "dev": true,
       "requires": {
-        "fbjs": "0.8.14",
+        "fbjs": "0.8.15",
         "object-assign": "4.1.1"
       }
     },
@@ -5501,12 +5506,11 @@
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpu-core": {
@@ -5603,15 +5607,15 @@
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.5",
-            "mime-types": "2.1.16"
+            "mime-types": "2.1.17"
           },
           "dependencies": {
             "mime-types": {
-              "version": "2.1.16",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-              "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+              "version": "2.1.17",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+              "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
               "requires": {
-                "mime-db": "1.29.0"
+                "mime-db": "1.30.0"
               }
             }
           }
@@ -5719,7 +5723,7 @@
       "resolved": "https://registry.npmjs.org/sane/-/sane-1.4.1.tgz",
       "integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
       "requires": {
-        "exec-sh": "0.2.0",
+        "exec-sh": "0.2.1",
         "fb-watchman": "1.9.2",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
@@ -5949,9 +5953,9 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
-      "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.17.tgz",
+      "integrity": "sha512-30c1Ch8FSjV0FwC253iftbbj0dU/OXoSg1LAEGZJUlGgjTNj6cu+DVqJWWIZJY5RXLWV4eFtR+4ouo0VIOYOTg==",
       "requires": {
         "source-map": "0.5.7"
       }
@@ -6156,9 +6160,9 @@
       }
     },
     "throat": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
+      "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
     "through": {
       "version": "2.3.8",
@@ -6250,15 +6254,15 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.16"
+        "mime-types": "2.1.17"
       },
       "dependencies": {
         "mime-types": {
-          "version": "2.1.16",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-          "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+          "version": "2.1.17",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
           "requires": {
-            "mime-db": "1.29.0"
+            "mime-db": "1.30.0"
           }
         }
       }
@@ -6457,6 +6461,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8="
+    },
+    "win-release": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+      "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+      "requires": {
+        "semver": "5.4.1"
+      }
     },
     "window-size": {
       "version": "0.1.0",

--- a/examples/webview_example/package.json
+++ b/examples/webview_example/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "react": "16.0.0-alpha.12",
-    "react-native": "0.47.2",
+    "react-native": "0.48.2",
     "react-native-branch": "file:../..",
     "react-native-deprecated-custom-components": "^0.1.1"
   },

--- a/examples/webview_example/package.json
+++ b/examples/webview_example/package.json
@@ -16,7 +16,7 @@
     "babel-jest": "19.0.0",
     "babel-preset-react-native": "1.9.1",
     "jest": "19.0.2",
-    "react-test-renderer": "~15.4.1"
+    "react-test-renderer": "16.0.0-alpha.12"
   },
   "jest": {
     "preset": "react-native"

--- a/examples/webview_example/yarn.lock
+++ b/examples/webview_example/yarn.lock
@@ -689,7 +689,7 @@ babel-preset-fbjs@^1.0.0:
     babel-plugin-transform-object-rest-spread "^6.6.5"
     object-assign "^4.0.1"
 
-babel-preset-fbjs@^2.1.0, babel-preset-fbjs@^2.1.4:
+babel-preset-fbjs@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/babel-preset-fbjs/-/babel-preset-fbjs-2.1.4.tgz#22f358e6654073acf61e47a052a777d7bccf03af"
   dependencies:
@@ -731,40 +731,6 @@ babel-preset-jest@^19.0.0:
 babel-preset-react-native@1.9.1:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/babel-preset-react-native/-/babel-preset-react-native-1.9.1.tgz#ec8e378274410d78f550fa9f8edd70353f3bb2fe"
-  dependencies:
-    babel-plugin-check-es2015-constants "^6.5.0"
-    babel-plugin-react-transform "2.0.2"
-    babel-plugin-syntax-async-functions "^6.5.0"
-    babel-plugin-syntax-class-properties "^6.5.0"
-    babel-plugin-syntax-flow "^6.5.0"
-    babel-plugin-syntax-jsx "^6.5.0"
-    babel-plugin-syntax-trailing-function-commas "^6.5.0"
-    babel-plugin-transform-class-properties "^6.5.0"
-    babel-plugin-transform-es2015-arrow-functions "^6.5.0"
-    babel-plugin-transform-es2015-block-scoping "^6.5.0"
-    babel-plugin-transform-es2015-classes "^6.5.0"
-    babel-plugin-transform-es2015-computed-properties "^6.5.0"
-    babel-plugin-transform-es2015-destructuring "^6.5.0"
-    babel-plugin-transform-es2015-for-of "^6.5.0"
-    babel-plugin-transform-es2015-function-name "^6.5.0"
-    babel-plugin-transform-es2015-literals "^6.5.0"
-    babel-plugin-transform-es2015-modules-commonjs "^6.5.0"
-    babel-plugin-transform-es2015-parameters "^6.5.0"
-    babel-plugin-transform-es2015-shorthand-properties "^6.5.0"
-    babel-plugin-transform-es2015-spread "^6.5.0"
-    babel-plugin-transform-es2015-template-literals "^6.5.0"
-    babel-plugin-transform-flow-strip-types "^6.5.0"
-    babel-plugin-transform-object-assign "^6.5.0"
-    babel-plugin-transform-object-rest-spread "^6.5.0"
-    babel-plugin-transform-react-display-name "^6.5.0"
-    babel-plugin-transform-react-jsx "^6.5.0"
-    babel-plugin-transform-react-jsx-source "^6.5.0"
-    babel-plugin-transform-regenerator "^6.5.0"
-    react-transform-hmr "^1.0.4"
-
-babel-preset-react-native@^1.9.1:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-react-native/-/babel-preset-react-native-1.9.2.tgz#b22addd2e355ff3b39671b79be807e52dfa145f2"
   dependencies:
     babel-plugin-check-es2015-constants "^6.5.0"
     babel-plugin-react-transform "2.0.2"
@@ -1418,6 +1384,14 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
+envinfo@^3.0.0:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-3.4.1.tgz#8c80e9f2eec2cd4e2adb2c5d0127ce07a2aaa2ae"
+  dependencies:
+    minimist "^1.2.0"
+    os-name "^2.0.1"
+    which "^1.2.14"
+
 "errno@>=0.1.1 <0.2.0-0", errno@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
@@ -1930,9 +1904,9 @@ iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
-image-size@^0.3.5:
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.3.5.tgz#83240eab2fb5b00b04aab8c74b0471e9cba7ad8c"
+image-size@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.1.tgz#98122a562d59dcc097ef1b2c8191866eb8f5d663"
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -2232,11 +2206,15 @@ jest-diff@^19.0.0:
     jest-matcher-utils "^19.0.0"
     pretty-format "^19.0.0"
 
-jest-docblock@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
+jest-docblock@20.1.0-chi.1:
+  version "20.1.0-chi.1"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-chi.1.tgz#06981ab0e59498a2492333b0c5502a82e4603207"
 
-jest-docblock@^20.1.0-alpha.3:
+jest-docblock@20.1.0-delta.4:
+  version "20.1.0-delta.4"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-delta.4.tgz#360d4f5fb702730c4136c4e71e5706188a694682"
+
+jest-docblock@^20.1.0-chi.1:
   version "20.1.0-echo.1"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.1.0-echo.1.tgz#be02f43ee019f97e6b83267c746ac7b40d290fe8"
 
@@ -2259,13 +2237,24 @@ jest-file-exists@^19.0.0:
   version "19.0.0"
   resolved "https://registry.yarnpkg.com/jest-file-exists/-/jest-file-exists-19.0.0.tgz#cca2e587a11ec92e24cfeab3f8a94d657f3fceb8"
 
-jest-haste-map@20.1.0-alpha.3:
-  version "20.1.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-alpha.3.tgz#37a1eea267cd770b99114a39c049a287501edf72"
+jest-haste-map@20.1.0-chi.1:
+  version "20.1.0-chi.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-chi.1.tgz#db5f5f31362c76e242b40ea9a3ccfa364719cee3"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-docblock "^20.1.0-alpha.3"
+    jest-docblock "^20.1.0-chi.1"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
+    worker-farm "^1.3.1"
+
+jest-haste-map@20.1.0-delta.4:
+  version "20.1.0-delta.4"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.1.0-delta.4.tgz#12e32b297a6dd49705cacde938029fc158834006"
+  dependencies:
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-docblock "20.1.0-delta.4"
     micromatch "^2.3.11"
     sane "^2.0.0"
     worker-farm "^1.3.1"
@@ -2278,17 +2267,6 @@ jest-haste-map@^19.0.0:
     graceful-fs "^4.1.6"
     micromatch "^2.3.11"
     sane "~1.5.0"
-    worker-farm "^1.3.1"
-
-jest-haste-map@^20.0.4:
-  version "20.0.5"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-20.0.5.tgz#abad74efb1a005974a7b6517e11010709cab9112"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-docblock "^20.0.3"
-    micromatch "^2.3.11"
-    sane "~1.6.0"
     worker-farm "^1.3.1"
 
 jest-jasmine2@^19.0.2:
@@ -2678,6 +2656,10 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+macos-release@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/macos-release/-/macos-release-1.1.0.tgz#831945e29365b470aa8724b0ab36c8f8959d10fb"
+
 makeerror@1.0.x:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/makeerror/-/makeerror-1.0.11.tgz#e01a5c9109f2af79660e4e8b9587790184f5a96c"
@@ -2711,9 +2693,9 @@ methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-metro-bundler@^0.9.0:
-  version "0.9.2"
-  resolved "https://registry.yarnpkg.com/metro-bundler/-/metro-bundler-0.9.2.tgz#a23c1e0c28fc920f4280980dc7c3bb54e51d0240"
+metro-bundler@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/metro-bundler/-/metro-bundler-0.11.0.tgz#ba5d2ae34943da28a37c2098047ad265c16fddf4"
   dependencies:
     absolute-path "^0.0.0"
     async "^2.4.0"
@@ -2721,8 +2703,8 @@ metro-bundler@^0.9.0:
     babel-generator "^6.24.1"
     babel-plugin-external-helpers "^6.18.0"
     babel-preset-es2015-node "^6.1.1"
-    babel-preset-fbjs "^2.1.0"
-    babel-preset-react-native "^1.9.1"
+    babel-preset-fbjs "^2.1.4"
+    babel-preset-react-native "^2.0.0"
     babel-register "^6.24.1"
     babylon "^6.17.0"
     chalk "^1.1.1"
@@ -2732,8 +2714,9 @@ metro-bundler@^0.9.0:
     denodeify "^1.2.1"
     fbjs "0.8.12"
     graceful-fs "^4.1.3"
-    image-size "^0.3.5"
-    jest-haste-map "^20.0.4"
+    image-size "^0.6.0"
+    jest-docblock "20.1.0-chi.1"
+    jest-haste-map "20.1.0-chi.1"
     json-stable-stringify "^1.0.1"
     json5 "^0.4.0"
     left-pad "^1.1.3"
@@ -2745,7 +2728,7 @@ metro-bundler@^0.9.0:
     rimraf "^2.5.4"
     source-map "^0.5.6"
     temp "0.8.3"
-    throat "^3.0.0"
+    throat "^4.1.0"
     uglify-js "2.7.5"
     write-file-atomic "^1.2.0"
     xpipe "^1.0.5"
@@ -3045,6 +3028,13 @@ os-locale@^1.4.0:
   dependencies:
     lcid "^1.0.0"
 
+os-name@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/os-name/-/os-name-2.0.1.tgz#b9a386361c17ae3a21736ef0599405c9a8c5dc5e"
+  dependencies:
+    macos-release "^1.0.0"
+    win-release "^1.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -3261,15 +3251,15 @@ react-deep-force-update@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.0.1.tgz#f911b5be1d2a6fe387507dd6e9a767aa2924b4c7"
 
-react-devtools-core@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.3.1.tgz#dc83aba85735effe5e1dc386a1614cb5e8d0047d"
+react-devtools-core@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-2.5.0.tgz#5ad179f88f22d205940721e38e4ecc3a2d35bf03"
   dependencies:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
 "react-native-branch@file:../..":
-  version "2.0.0"
+  version "2.0.1"
 
 react-native-deprecated-custom-components@^0.1.1:
   version "0.1.1"
@@ -3281,9 +3271,9 @@ react-native-deprecated-custom-components@^0.1.1:
     react-timer-mixin "^0.13.2"
     rebound "^0.0.13"
 
-react-native@0.47.2:
-  version "0.47.2"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.47.2.tgz#5e55cd84e4947123c86d36ea6f95ab9ed2d0cb19"
+react-native@0.48.2:
+  version "0.48.2"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.48.2.tgz#9907d5a73640ade3920701e7096fc109ba9cc6e4"
   dependencies:
     absolute-path "^0.0.0"
     art "^0.10.0"
@@ -3315,6 +3305,7 @@ react-native@0.47.2:
     create-react-class "^15.5.2"
     debug "^2.2.0"
     denodeify "^1.2.1"
+    envinfo "^3.0.0"
     errno ">=0.1.1 <0.2.0-0"
     event-target-shim "^1.0.5"
     fbjs "0.8.12"
@@ -3324,13 +3315,13 @@ react-native@0.47.2:
     glob "^7.1.1"
     graceful-fs "^4.1.3"
     inquirer "^3.0.6"
-    jest-haste-map "20.1.0-alpha.3"
+    jest-haste-map "20.1.0-delta.4"
     json-stable-stringify "^1.0.1"
     json5 "^0.4.0"
     left-pad "^1.1.3"
     lodash "^4.16.6"
     merge-stream "^1.0.1"
-    metro-bundler "^0.9.0"
+    metro-bundler "^0.11.0"
     mime "^1.3.4"
     mime-types "2.1.11"
     minimist "^1.2.0"
@@ -3344,7 +3335,7 @@ react-native@0.47.2:
     promise "^7.1.1"
     prop-types "^15.5.8"
     react-clone-referenced-element "^1.0.1"
-    react-devtools-core "2.3.1"
+    react-devtools-core "^2.5.0"
     react-timer-mixin "^0.13.2"
     react-transform-hmr "^1.0.4"
     rebound "^0.0.13"
@@ -3357,7 +3348,7 @@ react-native@0.47.2:
     source-map "^0.5.6"
     stacktrace-parser "^0.1.3"
     temp "0.8.3"
-    throat "^3.0.0"
+    throat "^4.1.0"
     whatwg-fetch "^1.0.0"
     wordwrap "^1.0.0"
     write-file-atomic "^1.2.0"
@@ -3654,18 +3645,6 @@ sane@~1.5.0:
     walker "~1.0.5"
     watch "~0.10.0"
 
-sane@~1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
-  dependencies:
-    anymatch "^1.3.0"
-    exec-sh "^0.2.0"
-    fb-watchman "^1.8.0"
-    minimatch "^3.0.2"
-    minimist "^1.1.1"
-    walker "~1.0.5"
-    watch "~0.10.0"
-
 sax@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
@@ -3674,7 +3653,7 @@ sax@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.1.6.tgz#5d616be8a5e607d54e114afae55b7eaf2fcc3240"
 
-"semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.x, semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
@@ -3974,6 +3953,10 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
+throat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
+
 through2@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -4196,7 +4179,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.1.1, which@^1.2.12, which@^1.2.9:
+which@^1.1.1, which@^1.2.12, which@^1.2.14, which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:
@@ -4207,6 +4190,12 @@ wide-align@^1.1.0:
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
+
+win-release@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
+  dependencies:
+    semver "^5.0.1"
 
 window-size@0.1.0:
   version "0.1.0"

--- a/examples/webview_example/yarn.lock
+++ b/examples/webview_example/yarn.lock
@@ -1560,7 +1560,7 @@ fbjs@0.8.12:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.4, fbjs@^0.8.9, fbjs@~0.8.9:
+fbjs@^0.8.9, fbjs@~0.8.9:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
   dependencies:
@@ -3366,11 +3366,11 @@ react-proxy@^1.1.7:
     lodash "^4.6.1"
     react-deep-force-update "^1.0.0"
 
-react-test-renderer@~15.4.1:
-  version "15.4.2"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.4.2.tgz#27e1dff5d26d0e830f99614c487622bc831416f3"
+react-test-renderer@16.0.0-alpha.12:
+  version "16.0.0-alpha.12"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.0.0-alpha.12.tgz#9e4cc5d8ce8bfca72778340de3e1454b9d6c0cc5"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.9"
     object-assign "^4.1.0"
 
 react-timer-mixin@^0.13.2:


### PR DESCRIPTION
Updated `testbed_simple` and `webview_example` to use RN 0.48.2 using `react-native-git-upgrade`.