### PR TITLE
Fix openURL iOS native method compilation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ In AppDelegate.m
         // do other deep link routing for the Facebook SDK, Pinterest SDK, etc
         return YES;
     }
+    return NO;
 }
 
 - (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray *restorableObjects))restorationHandler {


### PR DESCRIPTION
I was following the setup documentation but running into a compilation failure with the native method `openURL`, which you have to put inside the _AppDelegate.m_ file, according to the README.

The error message:
__Semantic issue: Control may reach end of non-void function.__

Here's a printscreen of it:
<img width="907" alt="screen shot 2017-09-12 at 5 37 27 pm" src="https://user-images.githubusercontent.com/532254/30349815-581c1de2-97e2-11e7-95cb-76aaa818a196.png">

Just adding a `return NO;` at the end of the function fixed it.