### PR TITLE
Allow loading rewards for different buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,8 +1029,12 @@ you will need to make an asynchronous call to retrieve the balance.
 #### Method
 
 ```js
-branch.loadRewards()
+branch.loadRewards(bucket)
 ```
+
+##### Parameters
+
+**bucket**: (Optional) The bucket to get the credit balance for
 
 ##### Return
 
@@ -1039,7 +1043,7 @@ branch.loadRewards()
 ```js
 import branch from 'react-native-branch'
 
-let rewards = await branch.loadRewards()
+let rewards = await branch.loadRewards(bucket)
 ```
 
 ### Redeem All or Some of the Reward Balance (Store State)

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -585,9 +585,9 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void loadRewards(Promise promise)
+    public void loadRewards(String bucket, Promise promise)
     {
-        Branch.getInstance().loadRewards(new LoadRewardsListener(promise));
+        Branch.getInstance().loadRewards(new LoadRewardsListener(bucket, promise));
     }
 
     @ReactMethod
@@ -648,16 +648,23 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
     protected class LoadRewardsListener implements Branch.BranchReferralStateChangedListener
     {
+        private String _bucket;
         private Promise _promise;
 
-        public LoadRewardsListener(Promise promise) {
+        public LoadRewardsListener(String bucket, Promise promise) {
+            this._bucket = bucket;
             this._promise = promise;
         }
 
         @Override
         public void onStateChanged(boolean changed, BranchError error) {
             if (error == null) {
-                int credits = Branch.getInstance().getCredits();
+                int credits = 0;
+                if (this._bucket == null) {
+                  credits = Branch.getInstance().getCredits();
+                } else {
+                  credits = Branch.getInstance().getCreditsForBucket(this._bucket);
+                }
                 WritableMap map = new WritableNativeMap();
                 map.putInt("credits", credits);
                 this._promise.resolve(map);

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -466,12 +466,18 @@ RCT_EXPORT_METHOD(
 
 #pragma mark loadRewards
 RCT_EXPORT_METHOD(
-                  loadRewards:(RCTPromiseResolveBlock)resolve
+                  loadRewards:(NSString *)bucket
+                  resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject
                   ) {
     [self.class.branch loadRewardsWithCallback:^(BOOL changed, NSError *error) {
         if(!error) {
-            int credits = (int)[self.class.branch getCredits];
+            int credits = 0;
+            if (bucket) {
+                credits = (int)[self.class.branch getCreditsForBucket:bucket];
+            } else {
+                credits = (int)[self.class.branch getCredits];
+            }
             resolve(@{@"credits": @(credits)});
         } else {
             RCTLogError(@"Load Rewards Error: %@", error.localizedDescription);

--- a/src/index.js
+++ b/src/index.js
@@ -104,7 +104,7 @@ class Branch {
 
   /*** Referral Methods ***/
   redeemRewards = (amount, bucket) => RNBranch.redeemRewards(amount, bucket)
-  loadRewards = RNBranch.loadRewards
+  loadRewards = (bucket) => RNBranch.loadRewards(bucket)
   getCreditHistory = RNBranch.getCreditHistory
 
   /*** BranchUniversalObject ***/


### PR DESCRIPTION
This allows you to specify a bucket for which to load rewards. I saw this was implemented in the Cordova version so I added it here.

Linting and tests pass, and I checked that this works on  both platforms. Let me know if this looks good!