### PR TITLE
Return RNBranch::Error::DuplicateResourceError from generateShortUrl

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -418,11 +418,18 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
             @Override
             public void onLinkCreate(String url, BranchError error) {
                 Log.d(REACT_CLASS, "onLinkCreate " + url);
+                if (error != null) {
+                    if (error.getErrorCode() == BranchError.ERR_BRANCH_DUPLICATE_URL) {
+                        promise.reject("RNBranch::Error::DuplicateResourceError", error.getMessage());
+                    }
+                    else {
+                        promise.reject("RNBranch::Error", error.getMessage());
+                    }
+                    return;
+                }
+
                 WritableMap map = new WritableNativeMap();
                 map.putString("url", url);
-                if (error != null) {
-                    map.putString("error", error.toString());
-                }
                 promise.resolve(map);
             }
         });

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -413,8 +413,12 @@ RCT_EXPORT_METHOD(
         if (!error) {
             RCTLogInfo(@"RNBranch Success");
             resolve(@{ @"url": url });
-        } else {
-            reject([NSString stringWithFormat: @"%lu", (long)error.code], error.localizedDescription, error);
+        }
+        else if (error.code == BNCDuplicateResourceError) {
+            reject(@"RNBranch::Error::DuplicateResourceError", error.localizedDescription, error);
+        }
+        else {
+            reject(@"RNBranch::Error", error.localizedDescription, error);
         }
     }];
 }


### PR DESCRIPTION
In case an alias is taken, return a standardized error code to JS.