### PR TITLE
fixing import to work correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Modify your AppDelegate as follows:
 In AppDelegate.m
 
 ```objective-c
-#import <react-native-branch/RNBranch.h> // at the top
+#import "RNBranch.h" // at the top
 
 // Initialize the Branch Session at the top of existing application:didFinishLaunchingWithOptions:
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions


### PR DESCRIPTION
When installing via pods for ios, the documentation recommends using:
```objective-c
#import <react-native-branch/RNBranch.h> // at the top
```
To import the project, however this causes a file not found error. To correct:
```objective-c
#import "RNBranch.h"
```