### PR TITLE
Enable multidexing in all Android examples

### DIFF
--- a/examples/browser_example/android/app/build.gradle
+++ b/examples/browser_example/android/app/build.gradle
@@ -97,6 +97,7 @@ android {
         applicationId "com.browser_example"
         minSdkVersion 16
         targetSdkVersion 22
+        multiDexEnabled true
         versionCode 1
         versionName "1.0"
         ndk {

--- a/examples/browser_example/android/app/src/main/java/com/browser_example/MainApplication.java
+++ b/examples/browser_example/android/app/src/main/java/com/browser_example/MainApplication.java
@@ -1,6 +1,8 @@
 package com.browser_example;
 
-import android.app.Application;
+import android.content.Context;
+import android.support.multidex.MultiDex;
+import android.support.multidex.MultiDexApplication;
 
 import com.facebook.react.ReactApplication;
 
@@ -14,7 +16,7 @@ import com.facebook.soloader.SoLoader;
 import java.util.Arrays;
 import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
+public class MainApplication extends MultiDexApplication implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -41,5 +43,11 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     Branch.getAutoInstance(this);
+  }
+
+  @Override
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
   }
 }

--- a/examples/testbed_native_android/android/app/build.gradle
+++ b/examples/testbed_native_android/android/app/build.gradle
@@ -7,6 +7,7 @@ android {
         applicationId "io.branch.testbed_native_android"
         minSdkVersion 16
         targetSdkVersion 25
+        multiDexEnabled true
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/examples/testbed_native_android/android/app/src/main/java/io/branch/testbed_native_android/MainApplication.java
+++ b/examples/testbed_native_android/android/app/src/main/java/io/branch/testbed_native_android/MainApplication.java
@@ -1,6 +1,8 @@
 package io.branch.testbed_native_android;
 
-import android.app.Application;
+import android.content.Context;
+import android.support.multidex.MultiDex;
+import android.support.multidex.MultiDexApplication;
 
 import io.branch.referral.Branch;
 
@@ -8,10 +10,16 @@ import io.branch.referral.Branch;
  * Created by jdee on 3/30/17.
  */
 
-public class MainApplication extends Application {
+public class MainApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
         Branch.getAutoInstance(this);
+    }
+
+    @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        MultiDex.install(this);
     }
 }

--- a/examples/testbed_simple/android/app/build.gradle
+++ b/examples/testbed_simple/android/app/build.gradle
@@ -97,6 +97,7 @@ android {
         applicationId "com.testbed_simple"
         minSdkVersion 16
         targetSdkVersion 22
+        multiDexEnabled true
         versionCode 1
         versionName "1.0"
         ndk {

--- a/examples/testbed_simple/android/app/src/main/java/com/testbed_simple/MainApplication.java
+++ b/examples/testbed_simple/android/app/src/main/java/com/testbed_simple/MainApplication.java
@@ -1,6 +1,8 @@
 package com.testbed_simple;
 
-import android.app.Application;
+import android.content.Context;
+import android.support.multidex.MultiDex;
+import android.support.multidex.MultiDexApplication;
 
 import com.facebook.react.ReactApplication;
 import io.branch.rnbranch.RNBranchPackage;
@@ -14,7 +16,7 @@ import com.facebook.soloader.SoLoader;
 import java.util.Arrays;
 import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
+public class MainApplication extends MultiDexApplication implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -41,5 +43,11 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     Branch.getAutoInstance(this);
+  }
+
+  @Override
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
   }
 }

--- a/examples/webview_example/android/app/src/main/java/com/webview_example/MainApplication.java
+++ b/examples/webview_example/android/app/src/main/java/com/webview_example/MainApplication.java
@@ -1,6 +1,8 @@
 package com.webview_example;
 
-import android.app.Application;
+import android.content.Context;
+import android.support.multidex.MultiDex;
+import android.support.multidex.MultiDexApplication;
 
 import com.facebook.react.ReactApplication;
 import io.branch.rnbranch.RNBranchPackage;
@@ -14,7 +16,7 @@ import com.facebook.soloader.SoLoader;
 import java.util.Arrays;
 import java.util.List;
 
-public class MainApplication extends Application implements ReactApplication {
+public class MainApplication extends MultiDexApplication implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -41,5 +43,11 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
     Branch.getAutoInstance(this);
+  }
+
+  @Override
+  protected void attachBaseContext(Context base) {
+    super.attachBaseContext(base);
+    MultiDex.install(this);
   }
 }


### PR DESCRIPTION
Judging from problem reports, a lot of production apps enable multidexing. This has an effect on error messages, etc. Enabling multidexing in all the example Android apps to better match production apps.

This may be related to #256.