### PR TITLE
Fix incorrect event type when error = null

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -201,7 +201,8 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
             @Override
             public void onReceive(Context context, Intent intent) {
-                final String eventName = initSessionResult.has("error") ? RN_INIT_SESSION_ERROR_EVENT : RN_INIT_SESSION_SUCCESS_EVENT;
+                final boolean hasError = (initSessionResult.has("error") && !initSessionResult.isNull("error"));
+                final String eventName = hasError ? RN_INIT_SESSION_ERROR_EVENT : RN_INIT_SESSION_SUCCESS_EVENT;
                 mBranchModule.sendRNEvent(eventName, convertJsonToMap(initSessionResult));
             }
 


### PR DESCRIPTION
I get the following below session params. Because error is populated as a key (but has value of `null`), the sdk categorizes the initialization as a`RNBranch.initSessionError` event.  This PR fixes that.
```
{
	"params": {
		"$og_title": "...",
		"$publicly_indexable": 0,
		"~creation_source": 3,
		"$og_description": "...",
		"+click_timestamp": 1510001640,
		"+from_facebook_ad": true,
		"$identity_id": 359755702476408775,
		"$og_image_url": "...",
		"+match_guaranteed": true,
		"$canonical_identifier": "...",
		"+clicked_branch_link": true,
		"$one_time_use": false,
		"~id": 455075964863574517,
		"+is_first_session": false,
		"~referring_link": "...",
		"$exp_date": 0
	},
	"error": null,
	"uri": "..."
}
```