### PR TITLE
Handle expired BUOs in BranchEvent.logEvent()

### DIFF
--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -46,10 +46,20 @@ export default async function createBranchUniversalObject(identifier, options = 
       return this._tryFunction(RNBranch.userCompletedActionOnUniversalObject, event, state)
     },
     logEvent(eventName, params = {}) {
-      new BranchEvent(eventName, this, params).logEvent()
+      return new BranchEvent(eventName, this, params).logEvent()
     },
     release() {
-      RNBranch.releaseUniversalObject(this.ident)
+      return RNBranch.releaseUniversalObject(this.ident)
+    },
+
+    /**
+     * Used by exception handlers when RNBranch::Error::BUONotFound is caught.
+     */
+    _newIdent() {
+      return RNBranch.createUniversalObject(branchUniversalObject).then(({ident}) => {
+        this.ident = ident
+        return ident
+      })
     },
 
     _tryFunction(func, ...args) {
@@ -57,10 +67,8 @@ export default async function createBranchUniversalObject(identifier, options = 
         if (error.code != 'RNBranch::Error::BUONotFound') {
           throw error
         }
-
-        return RNBranch.createUniversalObject(branchUniversalObject).then((response) => {
-          this.ident = response.ident
-          return func(response.ident, ...args)
+        return this._newIdent().then((ident) => {
+          return func(ident, ...args)
         })
       })
     }

--- a/test/BranchEventTest.js
+++ b/test/BranchEventTest.js
@@ -191,3 +191,11 @@ test('customData is correct', t => {
   t.is('object', typeof(event.customData))
   t.is('value', event.customData.key)
 })
+
+// --- _identFromMessage
+
+test('_identFromMessage parses a UUID from text', t => {
+  const event = new BranchEvent('Name')
+  const message = 'BranchUniversalObject not found for ident 16432373-05cb-4b42-85a0-55599e28c515.'
+  t.is('16432373-05cb-4b42-85a0-55599e28c515', event._identFromMessage(message))
+})


### PR DESCRIPTION
When a native BUO has expired from the native cache, any attempt to call a method on that BUO will result in `RNBranch::Error::BUONotFound` being raised. When working with a single BUO, this error is caught, a new native BUO is created, and the method is retried. Something similar is now done in `BranchEvent.logEvent()` in case multiple BUOs are attached to the same event. Any expired BUO is recreated and the method retried.