### PR TITLE
Automation updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "cocoapods", "~> 1.2"
-gem "fastlane", "~> 2.26"
+gem "fastlane", "~> 2.69"
 gem "rubocop"
 gem "travis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     faraday_middleware (0.12.2)
       faraday (>= 0.7.4, < 1.0)
     fastimage (2.1.0)
-    fastlane (2.68.2)
+    fastlane (2.69.0)
       CFPropertyList (>= 2.3, < 3.0.0)
       addressable (>= 2.3, < 3.0.0)
       babosa (>= 1.0.2, < 2.0.0)
@@ -107,7 +107,7 @@ GEM
       slack-notifier (>= 1.3, < 2.0.0)
       terminal-notifier (>= 1.6.2, < 2.0.0)
       terminal-table (>= 1.4.5, < 2.0.0)
-      tty-screen (~> 0.6.2)
+      tty-screen (~> 0.6.3)
       word_wrap (~> 1.0.0)
       xcodeproj (>= 1.5.2, < 2.0.0)
       xcpretty (>= 0.2.4, < 1.0.0)
@@ -185,20 +185,18 @@ GEM
     pusher-client (0.6.2)
       json
       websocket (~> 1.0)
-    rainbow (2.2.2)
-      rake
-    rake (12.3.0)
+    rainbow (3.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.1)
     rouge (2.0.7)
-    rubocop (0.51.0)
+    rubocop (0.52.0)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.4.0.2, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-macho (1.1.0)
@@ -251,7 +249,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.2)
-  fastlane (~> 2.26)
+  fastlane (~> 2.69)
   fastlane-plugin-branch
   fastlane-plugin-patch
   fastlane-plugin-yarn

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,6 +1,6 @@
 actions_path("lib")
 
-fastlane_version "2.26.1"
+fastlane_version "2.69.0"
 
 default_platform :ios
 

--- a/fastlane/lib/update_native_sdks.rb
+++ b/fastlane/lib/update_native_sdks.rb
@@ -81,13 +81,11 @@ module Fastlane
         end
 
         def commit
-          sh(
-            "git",
-            "commit",
-            "-a",
-            "-m",
-            "[Fastlane] Branch native SDK update: Android #{@android_version}, iOS #{@ios_version}"
-          )
+          message = "[Fastlane] Branch native SDK update:"
+          message << " #{@android_version} (Android)," if @android_update_needed
+          message << " #{@ios_version} (iOS)" if @ios_update_needed
+
+          sh "git", "commit", "-a", "-m", message.chomp(",")
         end
 
         def update_submodules(params)

--- a/fastlane/lib/update_native_sdks.rb
+++ b/fastlane/lib/update_native_sdks.rb
@@ -75,7 +75,7 @@ module Fastlane
         end
 
         def commit
-          sh "git commit -a -m'[Fastlane] Branch native SDK update: Android #{@android_version}, iOS #{@ios_version}'"
+          sh "git", "commit", "-a", "-m", "[Fastlane] Branch native SDK update: Android #{@android_version}, iOS #{@ios_version}"
         end
 
         def update_submodules(params)
@@ -114,9 +114,9 @@ module Fastlane
           # Remove the old and add the new
           Dir.chdir("#{@android_subdir}/libs") do
             old_jars = Dir['Branch*.jar']
-            sh "cp #{jar_path} ."
-            sh "git add Branch-#{version}.jar"
-            sh "git rm -f #{old_jars.join ' '}"
+            sh "cp", jar_path, "."
+            sh "git", "add", "Branch-#{version}.jar"
+            sh "git", "rm", "-f", *old_jars unless old_jars.empty?
           end
 
           # Patch build.gradle
@@ -138,8 +138,9 @@ module Fastlane
           branch_sdk_podspec_path = "#{@ios_subdir}/Branch-SDK.podspec"
 
           # Copy the podspec from the submodule
-          sh "cp native-sdks/ios/Branch.podspec #{branch_sdk_podspec_path}"
-          UI.user_error! "Unable to update #{branch_sdk_podspec_path}" unless $?.exitstatus == 0
+          sh "cp", "native-sdks/ios/Branch.podspec", branch_sdk_podspec_path do |status|
+            UI.user_error! "Unable to update #{branch_sdk_podspec_path}" unless status.success?
+          end
 
           # Change the pod name to Branch-SDK
           other_action.patch(

--- a/fastlane/lib/update_native_sdks.rb
+++ b/fastlane/lib/update_native_sdks.rb
@@ -22,28 +22,7 @@ module Fastlane
             update_ios_branch_source
             update_branch_podspec_from_submodule
             adjust_rnbranch_xcodeproj
-
-            # Updates to CocoaPods for unit tests and examples (requires
-            # node_modules for each)
-            %w{
-              examples/testbed_native_ios
-              examples/webview_example_native_ios
-              .
-            }.each { |f| other_action.yarn package_path: File.join("..", f, "package.json") }
-
-            %w{
-              examples/testbed_native_ios
-              examples/webview_example_native_ios
-              native-tests/ios
-            }.each do |folder|
-              other_action.cocoapods(
-                # relative to fastlane folder when using other_action
-                podfile: File.join("..", folder, "Podfile"),
-                silent: true,
-                use_bundle_exec: true
-              )
-              other_action.git_add(path: File.join("..", folder))
-            end
+            update_pods_in_tests_and_examples
           end
 
           commit if params[:commit]
@@ -183,6 +162,36 @@ module Fastlane
           )
 
           UI.success "Updated ios/Branch-SDK.podspec"
+        end
+
+        def update_pods_in_tests_and_examples
+          # Updates to CocoaPods for unit tests and examples (requires
+          # node_modules for each)
+          %w{
+            examples/testbed_native_ios
+            examples/webview_example_native_ios
+            .
+          }.each do |folder|
+            other_action.yarn package_path: File.join("..", folder, "package.json")
+
+            pods_folder = folder
+
+            # The Podfile there installs from node_modules in the repo root.
+            pods_folder = "native-tests/ios" if folder == "."
+
+            other_action.cocoapods(
+              # relative to fastlane folder when using other_action
+              podfile: File.join("..", pods_folder, "Podfile"),
+              silent: true,
+              use_bundle_exec: true
+            )
+
+            other_action.git_add(path: File.join("..", pods_folder))
+
+            # node_modules only required for pod install. Remove to speed up
+            # subsequent calls to yarn.
+            sh "rm", "-fr", File.join(folder, "node_modules")
+          end
         end
 
         def adjust_rnbranch_xcodeproj


### PR DESCRIPTION
Avoid unnecessary work when nothing has changed in one or either of the SDKs. Only include updated version numbers in commit messages for clarity.
