### PR TITLE
Automated version bump and bug fixes

### DIFF
--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReadableMap;
 
 import io.branch.referral.*;
 import io.branch.referral.Branch.BranchLinkCreateListener;
+import io.branch.referral.BuildConfig;
 import io.branch.referral.util.*;
 import io.branch.referral.Branch;
 import io.branch.indexing.*;
@@ -592,6 +593,8 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     private static Branch setupBranch(Context context) {
+        Log.i(REACT_CLASS, "Initializing Branch SDK v. " + BuildConfig.VERSION_NAME);
+
         RNBranchConfig config = new RNBranchConfig(context);
         String branchKey = config.getBranchKey();
         if (branchKey == null) branchKey = config.getUseTestInstance() ? config.getTestKey() : config.getLiveKey();

--- a/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
+++ b/android/src/main/java/io/branch/rnbranch/RNBranchModule.java
@@ -80,6 +80,7 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
 
     private static Activity mActivity = null;
     private static boolean mUseDebug = false;
+    private static boolean mInitialized = false;
 
     private AgingHash<String, BranchUniversalObject> mUniversalObjectMap = new AgingHash<>(AGING_HASH_TTL);
 
@@ -593,23 +594,17 @@ public class RNBranchModule extends ReactContextBaseJavaModule {
     }
 
     private static Branch setupBranch(Context context) {
-        Log.i(REACT_CLASS, "Initializing Branch SDK v. " + BuildConfig.VERSION_NAME);
+        Branch branch = Branch.getInstance(context);
 
-        RNBranchConfig config = new RNBranchConfig(context);
-        String branchKey = config.getBranchKey();
-        if (branchKey == null) branchKey = config.getUseTestInstance() ? config.getTestKey() : config.getLiveKey();
+        if (!mInitialized) {
+            Log.i(REACT_CLASS, "Initializing Branch SDK v. " + BuildConfig.VERSION_NAME);
 
-        /*
-         * This differs a little from iOS. If you add "useTestInstance": true to branch.json but
-         * don't add the testKey, on iOS, it will use the test key from the Info.plist if configured.
-         * On Android, useTestInstance in branch.json will be ignored unless testKey is present. If
-         * testKey is not specified in branch.json, it's necessary to add io.branch.sdk.TestMode to
-         * the Android manifest to use the test instance. It's not clear if there's a programmatic
-         * way to select the test key without specifying the key explicitly.
-         */
-        Branch branch = branchKey != null ? Branch.getInstance(context, branchKey) : Branch.getInstance(context);
+            RNBranchConfig config = new RNBranchConfig(context);
 
-        if (mUseDebug || config.getDebugMode()) branch.setDebug();
+            if (mUseDebug || config.getDebugMode()) branch.setDebug();
+
+            mInitialized = true;
+        }
 
         return branch;
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,4 +1,4 @@
-actions_path("lib")
+actions_path("lib/actions")
 
 fastlane_version "2.69.0"
 
@@ -29,4 +29,13 @@ lane :native_update do
   #   commit:               false, # Don't commit the results. Default: true
   #   verbose:               true  # Generate verbose output. Default: false
   # )
+end
+
+# Examples:
+# bundle exec fastlane bump # patch increment
+# bundle exec fastlane bump version:2.3.0 # update to any specific version
+# bundle exec fastlane bump tag:yes # add a tag after committing
+desc "Increment version number"
+lane :bump do |opts|
+  version_bump opts
 end

--- a/fastlane/lib/actions/update_native_sdks.rb
+++ b/fastlane/lib/actions/update_native_sdks.rb
@@ -1,4 +1,5 @@
 require "xcodeproj"
+require_relative "../helper/update_helper"
 
 module Fastlane
   module Actions
@@ -162,36 +163,6 @@ module Fastlane
           )
 
           UI.success "Updated ios/Branch-SDK.podspec"
-        end
-
-        def update_pods_in_tests_and_examples
-          # Updates to CocoaPods for unit tests and examples (requires
-          # node_modules for each)
-          %w{
-            examples/testbed_native_ios
-            examples/webview_example_native_ios
-            .
-          }.each do |folder|
-            other_action.yarn package_path: File.join("..", folder, "package.json")
-
-            pods_folder = folder
-
-            # The Podfile there installs from node_modules in the repo root.
-            pods_folder = "native-tests/ios" if folder == "."
-
-            other_action.cocoapods(
-              # relative to fastlane folder when using other_action
-              podfile: File.join("..", pods_folder, "Podfile"),
-              silent: true,
-              use_bundle_exec: true
-            )
-
-            other_action.git_add(path: File.join("..", pods_folder))
-
-            # node_modules only required for pod install. Remove to speed up
-            # subsequent calls to yarn.
-            sh "rm", "-fr", File.join(folder, "node_modules")
-          end
         end
 
         def adjust_rnbranch_xcodeproj

--- a/fastlane/lib/actions/version_bump.rb
+++ b/fastlane/lib/actions/version_bump.rb
@@ -1,0 +1,87 @@
+require "fastlane/action"
+require "active_support/core_ext/hash"
+require "pattern_patch"
+require_relative "../helper/update_helper"
+
+module Fastlane
+  module Actions
+    class VersionBumpAction < Action
+      class << self
+        def run(params)
+          version = new_version params
+
+          UI.message "Bumping to version #{version}."
+
+          update_package_json version
+          patch_index_js version
+          update_pods_in_tests_and_examples
+          sh "git", "commit", "-a", "-m", "[Fastlane] Version bump to #{version}"
+        end
+
+        def available_options
+          [
+            FastlaneCore::ConfigItem.new(
+              key: :version,
+              type: String,
+              description: "New version",
+              optional: true,
+              default_value: nil
+            ),
+            FastlaneCore::ConfigItem.new(
+              key: :tag,
+              is_string: false,
+              description: "Whether to tag after committing",
+              optional: true,
+              default_value: false
+            )
+          ]
+        end
+
+        def update_package_json(version)
+          package_json[:version] = version
+          json_text = JSON.generate(
+            package_json,
+            indent: "  ",
+            object_nl: "\n",
+            array_nl: "\n",
+            space: " "
+          )
+
+          File.write "package.json", "#{json_text}\n"
+        end
+
+        def patch_index_js(version)
+          PatternPatch::Patch.new(
+            regexp: /(VERSION = ")\d+\.\d+\.\d+/,
+            text: "\\1#{version}",
+            mode: :replace
+          ).apply "src/index.js"
+        end
+
+        def new_version(params)
+          version = params[:version]
+
+          if version.nil?
+            # Increment version from package.json
+            # Gem::Version doesn't seem to have a reasonable method for this.
+            components = current_version.split(".")
+            components[-1] = (components[-1].to_i + 1).to_s
+            version = components.join(".")
+          end
+
+          version
+        end
+
+        def current_version
+          package_json[:version]
+        end
+
+        def package_json
+          return @package_json if @package_json
+          @package_json = JSON.parse(File.read("package.json")).symbolize_keys
+          @package_json
+        end
+      end
+    end
+  end
+end

--- a/fastlane/lib/actions/version_bump.rb
+++ b/fastlane/lib/actions/version_bump.rb
@@ -16,6 +16,8 @@ module Fastlane
           patch_index_js version
           update_pods_in_tests_and_examples
           sh "git", "commit", "-a", "-m", "[Fastlane] Version bump to #{version}"
+          sh "git", "tag", version if params[:tag]
+          true
         end
 
         def available_options
@@ -41,7 +43,7 @@ module Fastlane
           package_json[:version] = version
           json_text = JSON.generate(
             package_json,
-            indent: "  ",
+            indent: " " * 2,
             object_nl: "\n",
             array_nl: "\n",
             space: " "
@@ -52,7 +54,7 @@ module Fastlane
 
         def patch_index_js(version)
           PatternPatch::Patch.new(
-            regexp: /(VERSION = ")\d+\.\d+\.\d+/,
+            regexp: /(\sVERSION\s*=\s*")\d+\.\d+\.\d+/,
             text: "\\1#{version}",
             mode: :replace
           ).apply "src/index.js"

--- a/fastlane/lib/helper/update_helper.rb
+++ b/fastlane/lib/helper/update_helper.rb
@@ -1,0 +1,33 @@
+module UpdateHelper
+  def update_pods_in_tests_and_examples
+    # Updates to CocoaPods for unit tests and examples (requires
+    # node_modules for each)
+    %w{
+      examples/testbed_native_ios
+      examples/webview_example_native_ios
+      .
+    }.each do |folder|
+      other_action.yarn package_path: File.join("..", folder, "package.json")
+
+      pods_folder = folder
+
+      # The Podfile there installs from node_modules in the repo root.
+      pods_folder = "native-tests/ios" if folder == "."
+
+      other_action.cocoapods(
+        # relative to fastlane folder when using other_action
+        podfile: File.join("..", pods_folder, "Podfile"),
+        silent: true,
+        use_bundle_exec: true
+      )
+
+      other_action.git_add(path: File.join("..", pods_folder))
+
+      # node_modules only required for pod install. Remove to speed up
+      # subsequent calls to yarn.
+      sh "rm", "-fr", File.join(folder, "node_modules")
+    end
+  end
+end
+
+include UpdateHelper

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -74,6 +74,7 @@ RCT_EXPORT_MODULE();
 
 + (void)setupBranchInstance:(Branch *)instance
 {
+    RCTLogInfo(@"Initializing Branch SDK v. %@", BNC_SDK_VERSION);
     RNBranchConfig *config = RNBranchConfig.instance;
     if (config.debugMode) {
         [instance setDebug];

--- a/src/branchUniversalObject.js
+++ b/src/branchUniversalObject.js
@@ -17,17 +17,15 @@ export default async function createBranchUniversalObject(identifier, options = 
     }
   }
 
-  // For the benefit of NSDecimalNumber on iOS.
-  const price = contentMetadata.price === undefined ? undefined : '' + contentMetadata.price
-
   const branchUniversalObject = {
     canonicalIdentifier: identifier,
-    contentMetadata: {
-      price: price,
-      ...contentMetadata
-    },
+    contentMetadata: contentMetadata,
     ...options
   }
+
+  // For the benefit of NSDecimalNumber on iOS.
+  const price = contentMetadata.price === undefined ? undefined : '' + contentMetadata.price
+  branchUniversalObject.contentMetadata.price = price
 
   if (options.automaticallyListOnSpotlight !== undefined) {
     console.info('[Branch] automaticallyListOnSpotlight is deprecated. Please use locallyIndex instead.')

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import createBranchUniversalObject from './branchUniversalObject'
 import BranchEvent from './BranchEvent'
 
 export const DEFAULT_INIT_SESSION_TTL = 5000
+export const VERSION = '2.2.2'
 
 export const AddToCartEvent = RNBranch.ADD_TO_CART_EVENT
 export const AddToWishlistEvent = RNBranch.ADD_TO_WISHLIST_EVENT
@@ -27,6 +28,8 @@ class Branch {
 
   constructor(options = {}) {
     if (options.debug) this._debug = true
+
+    console.info('Initializing react-native-branch v. ' + VERSION)
   }
 
   subscribe(listener) {


### PR DESCRIPTION
Added version reporting in the logs at initialization. The native SDK version and the react-native-branch version are both reported. There is also now a `VERSION` constant in index.js that indicates the current version.

Added a `bump` lane to the Fastfile for automating version bumps, which involves a sequence of yarn and pod update commands to make sure the Pods sandboxes are all updated as well as automatically updating the constant in index.js.

Fixed some other issues involving Android initialization and conversion of the contentMetadata.price field.