### PR TITLE
Get rid of unnecessary version check for iOS 8

### DIFF
--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -219,13 +219,8 @@ RCT_EXPORT_MODULE();
 - (UIViewController *)currentViewController
 {
     UIViewController *current = [UIApplication sharedApplication].keyWindow.rootViewController;
-    if (@available(iOS 8.0, *)) {
-        while (current.presentedViewController && ![current.presentedViewController isKindOfClass:UIAlertController.class]) {
-            current = current.presentedViewController;
-        }
-    } else {
-        // RN Requires iOS 8. Nothing to do here. Still.
-        while (current.presentedViewController) current = current.presentedViewController;
+    while (current.presentedViewController && ![current.presentedViewController isKindOfClass:UIAlertController.class]) {
+        current = current.presentedViewController;
     }
     return current;
 }


### PR DESCRIPTION
Probably related to #308.

The current release doesn't build with Xcode 8. Earlier versions of Xcode 9 were extremely pedantic about certain things. An unnecessary check for iOS 8 (RN only supports 8+) had to be introduced to silence a warning. However, this fails to build with Xcode 8, and removing the check no longer produces a warning in Xcode 9.