### PR TITLE
Use sync fs.unlink

### DIFF
--- a/scripts/androidUtil.js
+++ b/scripts/androidUtil.js
@@ -74,7 +74,7 @@ function removeSymbolicLink(path) {
     return
   }
 
-  fs.unlink(path)
+  fs.unlinkSync(path)
 }
 
 function ensureAndroidAssetsFolder(buildType) {


### PR DESCRIPTION
This ensures that errors get properly handled.

This will also cause issues with the upcoming Node.js 10.x. Refs: https://github.com/nodejs/node/pull/18668