### PR TITLE
Fix interpolated string in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,7 +1142,7 @@ branchUniversalObject.release()
 #### Example
 
 ```js
-import branch, { BranchEvent } from `react-native-branch
+import branch, { BranchEvent } from `react-native-branch`
 
 class CustomComponent extends Component {
   buo = null


### PR DESCRIPTION
Ensures correct code syntax highlighting in code example.