### PR TITLE
Added check for params property to not be null or undefined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,7 @@ class Branch {
       RNBranch.redeemInitSessionResult().then((result) => {
         if (result) {
           /*** Cached value is returned, so set it as cached. ***/
-          if('params' in result) {
+          if('params' in result && !!result['params']) {
             result['params']['cached_initial_event'] = true
           }
 


### PR DESCRIPTION
Related to issue #363

Fixed issue by adding a check that the `params` property is not `null` or `undefined`