### PR TITLE
Back out key support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,7 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    implementation files('libs/Branch-3.0.3.jar') // From node_modules
+    implementation 'io.branch.sdk.android:library:+'
+    // TODO: Resolve build issue with this jar.
+    // implementation files('libs/Branch-3.0.3.jar') // From node_modules
 }

--- a/examples/browser_example/android/app/build.gradle
+++ b/examples/browser_example/android/app/build.gradle
@@ -95,7 +95,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.browser_example"
@@ -139,7 +138,8 @@ android {
 
 dependencies {
     implementation project(':react-native-branch')
-    implementation fileTree(dir: "libs", include: ["*.jar"])
+    // implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "io.branch.sdk.android:library:3+"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/examples/browser_example/android/app/src/main/AndroidManifest.xml
+++ b/examples/browser_example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.browser_example" android:versionCode="1" android:versionName="1.0">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22"/>
+
     <application android:name=".MainApplication" android:allowBackup="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:theme="@style/AppTheme">
         <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize" android:launchMode="singleTask">
             <intent-filter>

--- a/examples/browser_example/android/build.gradle
+++ b/examples/browser_example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/browser_example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/browser_example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jan 27 20:48:54 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/examples/testbed_native_android/android/app/build.gradle
+++ b/examples/testbed_native_android/android/app/build.gradle
@@ -2,10 +2,8 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
     defaultConfig {
         applicationId "io.branch.testbed_native_android"
-        buildToolsVersion = "27.0.3"
         minSdkVersion = 16
         compileSdkVersion = 27
         targetSdkVersion = 26
@@ -33,7 +31,8 @@ android {
 }
 
 dependencies {
-    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    // implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "io.branch.sdk.android:library:3+"
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/examples/testbed_native_android/android/build.gradle
+++ b/examples/testbed_native_android/android/build.gradle
@@ -7,9 +7,10 @@ buildscript {
             url 'https://maven.google.com/'
             name 'Google'
         }
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/testbed_native_android/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/testbed_native_android/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 14 15:30:15 PST 2019
+#Sun Jan 27 21:08:44 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/examples/testbed_simple/android/app/build.gradle
+++ b/examples/testbed_simple/android/app/build.gradle
@@ -95,7 +95,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.testbed_simple"
@@ -139,7 +138,8 @@ android {
 
 dependencies {
     implementation project(':react-native-branch')
-    implementation fileTree(dir: "libs", include: ["*.jar"])
+    // implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "io.branch.sdk.android:library:3+"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/examples/testbed_simple/android/app/src/main/AndroidManifest.xml
+++ b/examples/testbed_simple/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.testbed_simple" android:versionCode="1" android:versionName="1.0">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22"/>
+
     <application android:name=".MainApplication" android:allowBackup="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:theme="@style/AppTheme">
         <activity android:name=".MainActivity" android:launchMode="singleTask" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/examples/testbed_simple/android/build.gradle
+++ b/examples/testbed_simple/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/testbed_simple/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/testbed_simple/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 16 15:27:27 PDT 2017
+#Sun Jan 27 20:32:06 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/examples/webview_example/android/app/build.gradle
+++ b/examples/webview_example/android/app/build.gradle
@@ -95,7 +95,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
         applicationId "com.webview_example"
@@ -139,7 +138,8 @@ android {
 
 dependencies {
     implementation project(':react-native-branch')
-    implementation fileTree(dir: "libs", include: ["*.jar"])
+    // implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation "io.branch.sdk.android:library:3+"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/examples/webview_example/android/app/src/main/AndroidManifest.xml
+++ b/examples/webview_example/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.webview_example" android:versionCode="1" android:versionName="1.0">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-    <uses-sdk android:minSdkVersion="16" android:targetSdkVersion="22"/>
+
     <application android:name=".MainApplication" android:allowBackup="true" android:label="@string/app_name" android:icon="@mipmap/ic_launcher" android:theme="@style/AppTheme">
         <activity android:name=".MainActivity" android:label="@string/app_name" android:configChanges="keyboard|keyboardHidden|orientation|screenSize" android:windowSoftInputMode="adjustResize" android:launchMode="singleTask">
             <intent-filter>

--- a/examples/webview_example/android/build.gradle
+++ b/examples/webview_example/android/build.gradle
@@ -13,7 +13,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/webview_example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/webview_example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Sun Jan 27 19:55:57 PST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/examples/webview_example/branch.debug.json
+++ b/examples/webview_example/branch.debug.json
@@ -1,6 +1,5 @@
 {
     "debugMode": true,
     "delayInitToCheckForSearchAds": true,
-    "appleSearchAdsDebugMode": true,
-    "deferInitializationForJSLoad": true
+    "appleSearchAdsDebugMode": true
 }

--- a/examples/webview_example/branch.json
+++ b/examples/webview_example/branch.json
@@ -1,4 +1,3 @@
 {
-    "delayInitToCheckForSearchAds": true,
-    "deferInitializationForJSLoad": true
+    "delayInitToCheckForSearchAds": true
 }

--- a/examples/webview_example/src/ArticleList.js
+++ b/examples/webview_example/src/ArticleList.js
@@ -35,7 +35,6 @@ class ArticleList extends Component {
   }
 
   componentDidMount() {
-    // branch.key = 'key_test_jmzd0lUR9gIiAAEQfo42onbcExe1MeHg'
     this._unsubscribeFromBranch = branch.subscribe(({ error, params }) => {
       if (error) {
         console.error("Error from Branch: " + error)

--- a/ios/RNBranch.m
+++ b/ios/RNBranch.m
@@ -163,10 +163,12 @@ RCT_EXPORT_MODULE();
 + (void)initSessionWithLaunchOptions:(NSDictionary *)launchOptions isReferrable:(BOOL)isReferrable {
     savedLaunchOptions = launchOptions;
     savedIsReferrable = isReferrable;
-    
-    if (!deferInitializationForJSLoad && !RNBranchConfig.instance.deferInitializationForJSLoad) [self initializeBranchSDK];
+
+    // Can't currently support this on Android.
+    // if (!deferInitializationForJSLoad && !RNBranchConfig.instance.deferInitializationForJSLoad) [self initializeBranchSDK];
+    [self initializeBranchSDK];
 }
-    
+
 + (void)initializeBranchSDK
 {
     [self.branch initSessionWithLaunchOptions:savedLaunchOptions isReferrable:savedIsReferrable andRegisterDeepLinkHandler:^(NSDictionary *params, NSError *error) {
@@ -307,8 +309,15 @@ RCT_EXPORT_METHOD(
 #pragma mark initializeBranch
 RCT_EXPORT_METHOD(initializeBranch:(NSString *)key
                   resolver:(RCTPromiseResolveBlock)resolve
-                  rejecter:(__unused RCTPromiseRejectBlock)reject
+                  rejecter:(RCTPromiseRejectBlock)reject
                   ) {
+    NSError *error = [NSError errorWithDomain:RNBranchErrorDomain
+                                         code:-1
+                                     userInfo:nil];
+    
+    reject(@"RNBranch::Error::Unsupported", @"Initializing the Branch SDK from JS will be supported in a future release.", error);
+
+    /*
     if (!deferInitializationForJSLoad && !RNBranchConfig.instance.deferInitializationForJSLoad) {
         // This is a no-op from JS unless [RNBranch deferInitializationForJSLoad] is called.
         resolve(0);
@@ -320,6 +329,7 @@ RCT_EXPORT_METHOD(initializeBranch:(NSString *)key
 
     [self.class initializeBranchSDK];
     resolve(0);
+    // */
 }
 
 #pragma mark redeemInitSessionResult

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,8 @@ class Branch {
     }
 
     // Initialize the native Branch SDK from JS
-    RNBranch.initializeBranch(this.key)
+    // -- Unsupportable on Android for the time being.
+    // RNBranch.initializeBranch(this.key)
 
     const unsubscribe = () => {
       this._removeListener(listener)


### PR DESCRIPTION
Supporting keys from JS requires some significant changes on the Android side. This may even involve modifications to the native Android SDK. I'm reviewing this with the Branch devs, to be resolved soon. Meanwhile, need to do a release.

This temporarily addresses a long-standing Android build issue by taking the Branch SDK from Maven from the time being, rather than from the jar in the repo.