### PR TITLE
Reset user session in all cases when isFromSelf

### DIFF
--- a/ios/Branch-SDK/Branch-SDK/Branch.m
+++ b/ios/Branch-SDK/Branch-SDK/Branch.m
@@ -784,10 +784,10 @@ static BOOL bnc_enableFingerprintIDInCrashlyticsReports = YES;
         NSDictionary *params = [BNCEncodingUtils decodeQueryStringToDictionary:query];
         if (params[@"link_click_id"]) {
             handled = YES;
-            if (isFromSelf) {
-                [self resetUserSession];
-            }
             self.preferenceHelper.linkClickIdentifier = params[@"link_click_id"];
+        }
+	if (isFromSelf) {
+            [self resetUserSession];
         }
     }
     [self initUserSessionAndCallCallback:(self.initializationStatus != BNCInitStatusInitialized)];


### PR DESCRIPTION
If you open a link `scheme://` without `link_click_id` while the application is running, it does not pass it to the JS `subscribe` method because the user session is not reset.

However, if you put the app in background and then foreground, it opens the link.

If we reset the user session in any case (`link_click_id` or not) if `isFromSelf == true`, it successfully call the JS `subscribe` method.