### PR TITLE
Segment fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docs",
     "ios",
     "react-native-branch.podspec",
+    "react-native-branch-segment.podspec",
     "scripts",
     "src"
   ],

--- a/react-native-branch-segment.podspec
+++ b/react-native-branch-segment.podspec
@@ -1,5 +1,8 @@
 require 'json'
 
+# Podspec specifically for use in hybrid apps with the Branch Segment integration.
+# Not for use in pure RN apps.
+
 # expect package.json in current dir
 package_json_filename = File.expand_path("./package.json", __dir__)
 
@@ -20,7 +23,7 @@ Pod::Spec.new do |s|
   s.platform     = :ios, "7.0"
   s.source       = { spec['repository']['type'].to_sym => spec['repository']['url'].sub(/^[a-z]+\+/, '') }
   s.source_files = [ "ios/*.h", "ios/*.m"]
-  s.header_dir   = "react_native_branch"
+  s.header_dir   = "react-native-branch"
   s.dependency 'Branch'
   s.dependency 'React' # to ensure the correct build order
 end

--- a/react-native-branch-segment.podspec
+++ b/react-native-branch-segment.podspec
@@ -1,0 +1,26 @@
+require 'json'
+
+# expect package.json in current dir
+package_json_filename = File.expand_path("./package.json", __dir__)
+
+# load the spec from package.json
+spec = JSON.load(File.read(package_json_filename))
+
+Pod::Spec.new do |s|
+  s.name             = "#{spec['name']}-segment"
+  s.version          = spec['version']
+  s.summary          = spec['description']
+  s.requires_arc = true
+  s.authors      = {
+                     'rt2zz' => 'zack@root-two.com',
+                     'Jimmy Dee' => 'jgvdthree@gmail.com'
+                   }
+  s.license      = spec['license']
+  s.homepage     = spec['homepage']
+  s.platform     = :ios, "7.0"
+  s.source       = { spec['repository']['type'].to_sym => spec['repository']['url'].sub(/^[a-z]+\+/, '') }
+  s.source_files = [ "ios/*.h", "ios/*.m"]
+  s.header_dir   = "react_native_branch"
+  s.dependency 'Branch'
+  s.dependency 'React' # to ensure the correct build order
+end


### PR DESCRIPTION
Addresses #401.

This adds a `react-native-branch-segment` pod that addresses a dependency conflict.

The pods here are only intended for use with hybrid apps: native iOS apps written in Swift or Obj-C that include one or more RN components. If you're using `react-native link` (or `rnpm link`) to build your app, the Branch native iOS SDK is embedded in the `react-native-branch` project.

To use this pod in an app using the Branch Segment integration, add this to your Podfile:

```Ruby
pod "react-native-branch-segment", path: "node_modules/react-native-branch" # or wherever your node_modules is
```

Instead of

```Ruby
pod "react-native-branch", path: "node_modules/react-native-branch"
pod "Branch-SDK", path: "node_modules/react-native-branch/ios"
```

Be sure you're not including the Branch-SDK pod from node_modules. This may not be the last word, but it fixes the conflict and may be considered an officially-supported solution.