### PR TITLE
Mention CocoaPods in README installation instructions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,40 +8,39 @@
   * NPM is not currently supported (#433). package-lock.json removed from all
     examples. NPM removed from instructions in docs.
 
-  **Updating to 3.0.0**
-    - If using the `cached_initial_event` parameter, change it to
-      `+rn_cached_initial_event`.
-    - \[Android] Add `implementation 'io.branch.sdk.android:library:3.+'` to `app/build.gradle`.
-    - \[Android] Change the call to `Branch.getAutoInstance` in `Application.onCreate` to
-      `RNBranchModule.getAutoInstance`.
-    - \[iOS] Add version 0.26.0 of the Branch pod to your Podfile:
+    **Updating to 3.0.0**
+      - If using the `cached_initial_event` parameter, change it to
+        `+rn_cached_initial_event`.
+      - \[Android] Add `implementation 'io.branch.sdk.android:library:3.+'` to `app/build.gradle`.
+      - \[Android] Change the call to `Branch.getAutoInstance` in `Application.onCreate` to
+        `RNBranchModule.getAutoInstance`.
+      - \[iOS] Add version 0.26.0 of the Branch pod to your Podfile:
 
-      **Pure RN app with react-native link**
-        - If you already have a Podfile, add `pod 'Branch', '0.26.0'`. Then run
-          `pod install`.
-        - If you don't have a Podfile, add one to your `ios` subdirectory using
-          these contents:
-          ```Ruby
-          platform :ios, "9.0"
+    **Pure RN app with react-native link**
+      - If you already have a Podfile, add `pod 'Branch', '0.26.0'`. Then run
+        `pod install`.
+      - If you don't have a Podfile, add one to your `ios` subdirectory using
+         these contents:
 
-          use_frameworks!
+        ```
+        platform :ios, "9.0"
+        use_frameworks!
+        pod "Branch", "0.26.0"
+        target "MyApp"
+        ```
 
-          pod "Branch", "0.26.0"
+        Change `MyApp` to the name of your application target. Install CocoaPods
+         if necessary: https://guides.cocoapods.org/using/getting-started.html#installation.
+         Run `pod install` in the ios subdirectory. Note that this creates a workspace called
+        `MyApp.xcworkspace` in the same directory. From now on, open the workspace,
+        not the project.
+      - Note that if your local podspec repo is quite old, you may need to update
+         it to get the current version of the Branch SDK. Do this by running
+         `pod install --repo-update` or by running `pod repo update` before
+         `pod install`.
 
-          target "MyApp"
-          ```
-          Change `MyApp` to the name of your application target. Install CocoaPods
-          if necessary: https://guides.cocoapods.org/using/getting-started.html#installation.
-          Run `pod install` in the ios subdirectory.
-          Note that this creates a workspace called `MyApp.xcworkspace` in the same
-          directory. From now on, open the workspace, not the project.
-        - Note that if your local podspec repo is quite old, you may need to update
-          it to get the current version of the Branch SDK. Do this by running
-          `pod install --repo-update` or by running `pod repo update` before
-          `pod install`.
-
-      **Native iOS app with the react-native-branch pod**
-        - Remove `pod 'Branch-SDK'` from your Podfile. Run `pod install`.
+    **Native iOS app with the react-native-branch pod**
+      - Remove `pod 'Branch-SDK'` from your Podfile. Run `pod install`.
 
 2019-03-27  Version 2.3.5
   * Remove docs folder from distro.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,25 @@ Note that the `react-native-branch` module requires `react-native` >= 0.40.
 1. `yarn add react-native-branch`
 2. (Optional) Add a branch.json file to the root of your app project. See https://rnbranch.app.link/branch-json.
 3. `react-native link react-native-branch`
-4. Follow the [setup instructions](#setup).
+4. Add the native Branch SDK via CocoaPods.
+    - Already using CocoaPods:
+      + Add `pod 'Branch', '0.26.0'` to your `Podfile`.
+      + Run `pod install`.
+    - Not using CocoaPods:
+      + Add a file to your `ios` subdirectory called
+        'Podfile' with these contents:
+        ```Ruby
+        platform :ios, "9.0"
+        use_frameworks!
+        pod "Branch", "0.26.0"
+        target "MyApp"
+        ```
+        Replace `MyApp` with the name of your application target.
+      + Install CocoaPods if necessary: https://guides.cocoapods.org/using/getting-started.html#installation.
+      + Run `pod install`.
+        Note that this creates a workspace called `MyApp.xcworkspace` in the same
+        directory. From now on, open the workspace, not the project.
+5. Follow the [setup instructions](#setup).
 
 **Note:** This SDK currently does not work in projects using NPM instead of yarn.
 See #433. The RN toolchain will use yarn by default. Please use
@@ -76,7 +94,9 @@ ___
 ### Native iOS app using the React pod
 
 Only follow these instructions if you are already using the React pod from node_modules. This is usually
-done in native apps that integrate a React Native components.
+done in native apps that integrate a React Native components. **Warning:** If you use the React pod in a
+project built with `react-native link`, you will have duplicate copies of the React Native components
+in your project, and the results will be unpredictable.
 
 1. Add the following to your Podfile:
     ```Ruby

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Note that the `react-native-branch` module requires `react-native` >= 0.40.
       + Run `pod install`.
         Note that this creates a workspace called `MyApp.xcworkspace` in the same
         directory. From now on, open the workspace, not the project.
+    - Note that if your local podspec repo is quite old, `pod install` may fail.
+      You may need to update the local podspec repo to get the current
+      version of the Branch SDK. Do this by running
+      `pod install --repo-update` or by running `pod repo update` before
+      `pod install`.
+
 5. Follow the [setup instructions](#setup).
 
 **Note:** This SDK currently does not work in projects using NPM instead of yarn.


### PR DESCRIPTION
This was omitted and only mentioned in the Release Notes and the ChangeLog (as well as the notes to #426).

Changes to the ChangeLog formatting to match the release notes for better MD formatting.