### PR TITLE
Use api in react-native-branch build.gradle for Branch SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,33 +121,23 @@ ___
 
 To fix a longstanding build issue with Android, it is necessary to take the
 native Branch Android SDK from Maven rather than from the react-native-branch
-module, starting with version 3.0.0.
+module, starting with version 3.0.0. This now happens transparently via Gradle.
+If you previously added `implementation fileTree(dir: 'libs', include: ['*.jar'])`
+to your `app/build.gradle` only for React Native Branch, you may remove it,
+unless it is now used by other code.
 
-Open the `android/app/build.gradle` file in your project.
+Remove any direct reference to `io.branch.sdk.android:library` in your dependencies,
+e.g. `io.branch.sdk.android:library:3.1.1`. This has the potential to cause
+conflicts. This module imports the Branch SDK directly.
 
-Remove this line:
-
-```gradle
-implementation fileTree(dir: 'libs', include: ['*.jar'])
-```
-
-Add this line:
-
-```gradle
-implementation "io.branch.sdk.android:library:3.1.2"
-```
-
-The result should be something like
+The result in your `app/build.gradle` should be something like
 ```gradle
 dependencies {
     implementation project(':react-native-branch')
-    implementation "io.branch.sdk.android:library:3.1.2"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }
 ```
-
-**Note:** Version 3.0.0-rc.1 uses version 3.1.1 of the native Branch SDK.
 
 If you're using an older version of Gradle, you may need `compile` instead of
 `implementation`.
@@ -287,26 +277,28 @@ ___
 
 #### Gradle dependency
 
-Add this line to your `dependencies` in `app/build.gradle`:
+If you use `react-native link`, no further change is necessary to your `app/build.gradle`.
+
+In a native app, import the `react-native-branch` project like this:
 
 ```gradle
-implementation "io.branch.sdk.android:library:3.1.2"
+implementation project(':react-native-branch')
 ```
 
-The result should be something like
+If you're using an older version of Gradle, you may need `compile` rather than
+`implementation`. If you are already using the native Branch SDK in your app,
+it will now be imported from Maven via `react-native-branch` as a dependency.
+Remove any reference to `io.branch.sdk.android:library` from your dependencies
+to avoid conflicts.
+
+Also add the project to your `setting.gradle`:
+
 ```gradle
-dependencies {
-    implementation project(':react-native-branch')
-    implementation "io.branch.sdk.android:library:3.1.2"
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    implementation "com.facebook.react:react-native:+"  // From node_modules
-}
+include ':react-native-branch'
+project(':react-native-branch').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-branch/android')
 ```
 
-**Note:** Version 3.0.0-rc.1 uses version 3.1.1 of the native Branch SDK.
-
-If you're using an older version of Gradle, you may need `compile` instead of
-`implementation`.
+The location of your `node_modules` folder may vary.
 
 #### Application code
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+' // From node_modules
-    implementation 'io.branch.sdk.android:library:3.1.2'
+    api 'io.branch.sdk.android:library:3.1.2'
 }

--- a/examples/browser_example/android/app/build.gradle
+++ b/examples/browser_example/android/app/build.gradle
@@ -138,7 +138,6 @@ android {
 
 dependencies {
     implementation project(':react-native-branch')
-    implementation "io.branch.sdk.android:library:3.1.2"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/examples/testbed_native_android/android/app/build.gradle
+++ b/examples/testbed_native_android/android/app/build.gradle
@@ -31,7 +31,6 @@ android {
 }
 
 dependencies {
-    implementation "io.branch.sdk.android:library:3.1.2"
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })

--- a/examples/testbed_simple/android/app/build.gradle
+++ b/examples/testbed_simple/android/app/build.gradle
@@ -138,7 +138,6 @@ android {
 
 dependencies {
     implementation project(':react-native-branch')
-    implementation "io.branch.sdk.android:library:3.1.2"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/examples/webview_example/android/app/build.gradle
+++ b/examples/webview_example/android/app/build.gradle
@@ -138,7 +138,6 @@ android {
 
 dependencies {
     implementation project(':react-native-branch')
-    implementation "io.branch.sdk.android:library:3.1.2"
     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
     implementation "com.facebook.react:react-native:+"  // From node_modules
 }

--- a/examples/webview_tutorial/README.md
+++ b/examples/webview_tutorial/README.md
@@ -169,23 +169,7 @@ Run `yarn` first to supply all dependencies in `node_modules`.
 
 ## Android setup
 
-1. Add this line to the `dependencies` in `android/app/build.gradle`:
-
-```gradle
-implementation "io.branch.sdk.android:library:3.1.2"
-```
-
-The result should be something like
-```gradle
-dependencies {
-    implementation project(':react-native-branch')
-    implementation "io.branch.sdk.android:library:3.1.2"
-    implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
-    implementation "com.facebook.react:react-native:+"  // From node_modules
-}
-```
-
-2. Open the `android` project in Android Studio. Open the `MainApplication.java` file in Android Studio.
+1. Open the `android` project in Android Studio. Open the `MainApplication.java` file in Android Studio.
     Alternately, open `android/app/src/main/java/com/webview_tutorial/MainApplication.java` in your
     favorite text editor. At the top of the file, after the `package` declaration, add the following line:
 
@@ -193,7 +177,7 @@ dependencies {
     import io.branch.rnbranch.RNBranchModule;
     ```
 
-3. In the `onCreate` method, add the following line:
+2. In the `onCreate` method, add the following line:
 
     ```Java
     RNBranch.getAutoInstance(this);
@@ -204,7 +188,7 @@ dependencies {
     ```Java
     package com.webview_tutorial;
 
-    // Step 2: Add RNBranchModule import
+    // Step 1: Add RNBranchModule import
     import io.branch.rnbranch.RNBranchModule;
 
     import android.app.Application;
@@ -244,13 +228,13 @@ dependencies {
         super.onCreate();
         SoLoader.init(this, /* native exopackage */ false);
 
-        // Step 3: Add call to RNBranch.getAutoInstance
+        // Step 2: Add call to RNBranch.getAutoInstance
         RNBranch.getAutoInstance(this);
       }
     }
     ```
 
-4. Open the `android/app/src/main/java/com/webview_tutorial/MainActivity.java` file in Android Studio
+3. Open the `android/app/src/main/java/com/webview_tutorial/MainActivity.java` file in Android Studio
     or your favorite editor. Add the following imports near the top of the file:
 
     ```Java
@@ -258,7 +242,7 @@ dependencies {
     import android.content.Intent;
     ```
 
-5. Add the `onStart` method in the MainActivity:
+4. Add the `onStart` method in the MainActivity:
 
     ```Java
     @Override
@@ -268,7 +252,7 @@ dependencies {
     }
     ```
 
-6. Add the `onNewIntent` method in the MainActivity:
+5. Add the `onNewIntent` method in the MainActivity:
 
     ```Java
     @Override
@@ -283,7 +267,7 @@ dependencies {
     ```Java
     package com.webview_tutorial;
 
-    // Step 4: Import RNBranchModule and Android Intent class
+    // Step 3: Import RNBranchModule and Android Intent class
     import io.branch.rnbranch.RNBranchModule;
     import android.content.Intent;
 
@@ -300,14 +284,14 @@ dependencies {
             return "webview_tutorial";
         }
 
-        // Step 5: Add onStart method
+        // Step 4: Add onStart method
         @Override
         protected void onStart() {
             super.onStart();
             RNBranchModule.initSession(getIntent().getData(), this);
         }
 
-        // Step 6: Add onNewIntent method
+        // Step 5: Add onNewIntent method
         @Override
         public void onNewIntent(Intent intent) {
             super.onNewIntent(intent);
@@ -317,7 +301,7 @@ dependencies {
     }
     ```
 
-7. Open the `android/app/src/main/AndroidManifest.xml` in Android Studio or a text editor. Add
+6. Open the `android/app/src/main/AndroidManifest.xml` in Android Studio or a text editor. Add
     `android:launchMode="singleTask"` to the MainActivity:
 
     ```xml
@@ -329,7 +313,7 @@ dependencies {
         android:launchMode="singleTask">
     ```
 
-8. Add `intent-filters` to the MainActivity in the Android manifest using your Branch domains:
+7. Add `intent-filters` to the MainActivity in the Android manifest using your Branch domains:
 
     ```xml
     <intent-filter android:autoVerify="true">
@@ -360,7 +344,7 @@ dependencies {
 
     Replace `myurischeme` with your actual URI scheme.
 
-9. Add your Branch keys to the Android manifest at the end of the application element.
+8. Add your Branch keys to the Android manifest at the end of the application element.
 
     ```xml
     <!-- Branch keys -->
@@ -430,7 +414,7 @@ dependencies {
     </manifest>
     ```
 
-10. Add a file called `android/app/src/debug/AndroidManifest.xml` with the following contents:
+9. Add a file called `android/app/src/debug/AndroidManifest.xml` with the following contents:
 
     ```xml
     <manifest xmlns:android="http://schemas.android.com/apk/res/android"
@@ -443,7 +427,7 @@ dependencies {
     </manifest>
     ```
 
-11. Open the file `android/app/proguard-rules.pro` and add the following line at the end:
+10. Open the file `android/app/proguard-rules.pro` and add the following line at the end:
 
     ```proguard
     -dontwarn io.branch.**

--- a/examples/webview_tutorial/android/app/proguard-rules.pro
+++ b/examples/webview_tutorial/android/app/proguard-rules.pro
@@ -15,3 +15,5 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+# Step 10: Add -dontwarn io.branch.**

--- a/examples/webview_tutorial/android/app/src/main/java/com/webview_tutorial/MainActivity.java
+++ b/examples/webview_tutorial/android/app/src/main/java/com/webview_tutorial/MainActivity.java
@@ -1,6 +1,6 @@
 package com.webview_tutorial;
 
-// Step 4: Import RNBranchModule and Android Intent class
+// Step 3: Import RNBranchModule and Android Intent class
 
 import com.facebook.react.ReactActivity;
 
@@ -15,6 +15,8 @@ public class MainActivity extends ReactActivity {
         return "webview_tutorial";
     }
 
-    // Step 5: Add onStart method
+    // Step 4: Add onStart method
+
+    // Step 5: Add onNewIntent method
 
 }

--- a/examples/webview_tutorial/android/app/src/main/java/com/webview_tutorial/MainApplication.java
+++ b/examples/webview_tutorial/android/app/src/main/java/com/webview_tutorial/MainApplication.java
@@ -1,6 +1,6 @@
 package com.webview_tutorial;
 
-// Step 2: Add RNBranchModule import
+// Step 1: Add RNBranchModule import
 
 import android.app.Application;
 
@@ -44,6 +44,6 @@ public class MainApplication extends Application implements ReactApplication {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
 
-    // Step 3: Add call to RNBranch.getAutoInstance
+    // Step 2: Add call to RNBranch.getAutoInstance
   }
 }

--- a/native-tests/android/app/build.gradle
+++ b/native-tests/android/app/build.gradle
@@ -19,7 +19,6 @@ android {
 }
 
 dependencies {
-    implementation "io.branch.sdk.android:library:3.1.2"
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })


### PR DESCRIPTION
This appears at last to be the right solution to the native Android SDK dependency and simplifies matters considerably. The build.gradle for this module now imports the SDK using `api` instead of `implementation`. This exposes the native Branch SDK to native code. This is necessary if you opt to continue using `Branch.getAutoInstance` in `Application.onCreate` instead of `RNBranchModule.getAutoInstance`, which is recommended, since that may be used to support other features in the future, but currently only required if you want to use branch.json to set your keys instead of setting them in the Android manifest.

This also facilitates integrating RN into a native Android app. Exposing the Branch SDK from this module helps prevent conflicts if the native app is also calling the native SDK.

Please remove any reference to `io.branch.sdk.android:library` from the `dependencies` in your `app/build.gradle`, e.g. `implementation 'io.branch.sdk.android:library:3.1.1'`.

The docs site will also need to be updated yet again to remove this instruction. See the changes to the README.md here.